### PR TITLE
Remove duplicate permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,6 @@
       <uses-permission android:name="android.permission.CAMERA" />
       <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-      <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
The "android.permission.READ_EXTERNAL_STORAGE" permission is mentioned twice. This removes one of them.