### PR TITLE
Fix for iOS on setBack to true

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -7,6 +7,12 @@
 
 @implementation CameraPreview
 
+-(void) pluginInitialize{
+    //make transparent
+      self.webView.opaque = NO;
+      self.webView.backgroundColor = [UIColor clearColor];
+}
+
 - (void) startCamera:(CDVInvokedUrlCommand*)command {
 
   CDVPluginResult *pluginResult;
@@ -43,7 +49,9 @@
       //make transparent
       self.webView.opaque = NO;
       self.webView.backgroundColor = [UIColor clearColor];
-      [self.webView.superview insertSubview:self.cameraRenderController.view belowSubview:self.webView];
+      //[self.webView.superview insertSubview:self.cameraRenderController.view belowSubview:self.webView];
+      [self.webView.superview addSubview:self.cameraRenderController.view];
+      [self.webView.superview bringSubviewToFront:self.webView];
     }
     else{
       self.cameraRenderController.view.alpha = (CGFloat)[command.arguments[8] floatValue];


### PR DESCRIPTION
The webView does not get the change to be set as opaque and the insertSubview will also not work. The latest cordova release explains on how to set the webView before cordova adds html element. using the - (void) pluginInitialize {}
ref. https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md