### PR TITLE
Fix Xcode warning for missing getSupportedPictureSizes

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -210,8 +210,8 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void) getSupportedPictureSize:(CDVInvokedUrlCommand*)command {
-  NSLog(@"getSupportedPictureSize");
+- (void) getSupportedPictureSizes:(CDVInvokedUrlCommand*)command {
+  NSLog(@"getSupportedPictureSizes");
   CDVPluginResult *pluginResult;
 
   if(self.sessionManager != nil){


### PR DESCRIPTION
Looks like the 's' was dropped (but only in iOS) in 80221ed.