### PR TITLE
takepicture now uses camera instead of preview 

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -15,6 +15,8 @@ import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.YuvImage;
 import android.hardware.Camera;
+import android.hardware.Camera.PictureCallback;
+import android.hardware.Camera.ShutterCallback;
 import android.os.Bundle;
 import android.util.Log;
 import android.util.DisplayMetrics;
@@ -328,10 +330,116 @@ public class CameraActivity extends Fragment {
     return ret;
   }
 
-  public void takePicture(final int width, final int height, final int quality){
-    Log.d(TAG, "picture taken");
+  public static Bitmap rotateBitmap(Bitmap source, float angle)
+  {
+      Matrix matrix = new Matrix();
+      matrix.postRotate(angle);
+      return Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
+  }
 
-    //final ImageView pictureView = (ImageView) view.findViewById(getResources().getIdentifier("picture_view", "id", appResourcesPackage));
+  ShutterCallback shutterCallback = new ShutterCallback()
+	{
+		 public void onShutter()
+		 {
+			 // Just do nothing.
+		 }
+	};
+
+	PictureCallback rawPictureCallback = new PictureCallback()
+	{
+		 public void onPictureTaken(byte[] arg0, Camera arg1)
+		 {
+			 // Just do nothing.
+		 }
+	};
+
+	PictureCallback jpegPictureCallback = new PictureCallback()
+	{
+    public void onPictureTaken(byte[] data, Camera arg1)
+		{
+			// Save the picture.
+      Log.d(TAG, "CameraPreview onPictureTaken");
+      Camera.Parameters params = mCamera.getParameters();
+			try {
+				Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0,data.length);
+        bitmap = rotateBitmap(bitmap, mPreview.getDisplayOrientation());
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+				bitmap.compress(Bitmap.CompressFormat.JPEG, params.getJpegQuality(), outputStream);
+        byte[] byteArray = outputStream.toByteArray();
+        String encodedImage = Base64.encodeToString(byteArray, Base64.NO_WRAP);
+        Log.d(TAG, "CameraPreview callbck javascript onPictureTaken");
+        eventListener.onPictureTaken(encodedImage);
+        Log.d(TAG, "CameraPreview done");
+        // result = outputStream.toByteArray();
+			}
+			catch (Exception e)
+			{
+        Log.d(TAG, "CameraPreview exception");
+				e.printStackTrace();
+			}
+		}
+	};
+
+  private Camera.Size getOptimalPictureSize(final int width, final int height, final Camera.Size previewSize, final List<Camera.Size> supportedSizes)
+  {
+    Camera.Size size = mCamera.new Size(width, height);
+    // convert to landscape if necessary
+    if (size.width < size.height) {
+      int temp = size.width;
+      size.width = size.height;
+      size.height = temp;
+    }
+    Log.d(TAG, "CameraPreview preview size " + previewSize.width + 'x' + previewSize.height);
+    // get the supportedPictureSize that:
+    // - has the closest aspect ratio to the preview aspectratio
+    // - has picture.width / picture.height closest to width and height
+    // - has the highest supporte pictured width / height if width == 0 || height == 0
+    double previewAspectRatio  = (double)previewSize.width / (double)previewSize.height;
+    if (previewAspectRatio < 1.0) {
+      // reset ratio to landscape
+      previewAspectRatio = 1.0 / previewAspectRatio;
+    }
+    Log.d(TAG, "CameraPreview previewAspectRatio " + previewAspectRatio);
+    double aspectTolerance = 0.1;
+    double bestDifference = Double.MAX_VALUE;
+    //for (int i = supportedSizes.size() - 1; i >= 0; i--) {
+    for (int i = 0; i < supportedSizes.size(); i++) {
+      Camera.Size supportedSize = supportedSizes.get(i);
+      Log.d(TAG, "CameraPreview supportedSize " + supportedSize.width + "x" + supportedSize.height);
+      double difference = Math.abs(previewAspectRatio - ((double)supportedSize.width / (double)supportedSize.height));
+      if (difference < bestDifference - aspectTolerance) {
+        // better aspectRatio found
+        size.width = supportedSize.width;
+        size.height = supportedSize.height;
+        bestDifference = difference;
+        Log.d(TAG, "CameraPreview better aspectRatio " + (double)supportedSize.width / (double)supportedSize.height);
+      } else if (difference < bestDifference + aspectTolerance) {
+        // same aspectRatio found (within tolerance), get highest supported resolution
+        if (width == 0 || height == 0) {
+          if (size.width < supportedSize.width) {
+            size.width = supportedSize.width;
+            size.height = supportedSize.height;
+          }
+        } else {
+          // check if this pictureSize closer to width/height
+          Log.d(TAG, "CameraPreview width x height " + width + "x" + height + ", supported width x height: "+ supportedSize.width + 'x' + supportedSize.height);
+          Log.d(TAG, "CameraPreview current size width x height " + size.width + 'x' + size.height);
+          Log.d(TAG, "CameraPreview opp new " + Math.abs(width - supportedSize.width) * Math.abs(height - supportedSize.height) + ", opp old:" + Math.abs(width - size.width) * Math.abs(width - size.height));
+          if (Math.abs(width - supportedSize.width) * Math.abs(height - supportedSize.height) <
+            Math.abs(width - size.width) * Math.abs(height - size.height)) {
+              size.width = supportedSize.width;
+              size.height = supportedSize.height;
+              Log.d(TAG, "CameraPreview better width/height " + size.width + 'x' + size.height);
+          }
+        }
+      }
+    }
+    Log.d(TAG, "CameraPreview optimalPictureSize " + size.width + 'x' + size.height);
+    return size;
+  }
+
+  public void takePicture(final int width, final int height, final int quality){
+    Log.d(TAG, "CameraPreview takePicture width: " + width + ", height: " + height + ", quality: " + quality);
 
     if(mPreview != null) {
 
@@ -341,6 +449,20 @@ public class CameraActivity extends Fragment {
 
       canTakePicture = false;
 
+      new Thread() {
+        public void run() {
+          // this approach based on http://ibuzzlog.blogspot.nl/2012/08/how-to-use-camera-in-android.html
+          Camera.Parameters params = mCamera.getParameters();
+          Camera.Size size = getOptimalPictureSize(width, height, params.getPreviewSize(), params.getSupportedPictureSizes());
+          //params.setPictureSize(424, 240); // always defined in landscape, rotate later if necessary
+          params.setPictureSize(size.width, size.height);
+          params.setJpegQuality(quality);
+          mCamera.setParameters(params);
+          mCamera.takePicture(shutterCallback, rawPictureCallback, jpegPictureCallback);
+        }
+      }.start();
+
+/*
       mPreview.setOneShotPreviewCallback(new Camera.PreviewCallback() {
 
         @Override
@@ -350,38 +472,7 @@ public class CameraActivity extends Fragment {
             public void run() {
               int w = width;
               int h = height;
-              /*
-              if(w == 0 || h == 0){
-                // dimensions not specified, set the highest resolution that
-                // best matches the current preview aspect ratio
-                Camera.Parameters params = camera.getParameters();
-                Log.d(TAG, "preview width: " + params.getPreviewSize().width + ", height: " + params.getPreviewSize().height);
-                double previewAspectRatio  = params.getPreviewSize().width / params.getPreviewSize().height;
-                if (previewAspectRatio < 1.0) {
-                  // reset ratio to landscape
-                  previewAspectRatio = 1 / previewAspectRatio;
-                }
-                double bestMatch = 10.0;
-                double matchTolerance = 0.01;
-                // scan supported sizes, starting at highest resolution
-                List<Camera.Size> sizeList = params.getSupportedPictureSizes();
-                for (int i = sizeList.size() - 1; i >= 0; i--) {
-                  double pictureAspectRatio = sizeList.get(i).width / sizeList.get(i).height;
-                  if (Math.abs(pictureAspectRatio - previewAspectRatio) < (bestMatch - matchTolerance)) {
-                    bestMatch = Math.abs(pictureAspectRatio - previewAspectRatio);
-                    if (width > height) {
-                      w = sizeList.get(i).width;
-                      h = sizeList.get(i).height;
-                    } else {
-                      w = sizeList.get(i).height;
-                      h = sizeList.get(i).width;
-                    }
-                    Log.d(TAG, "bestMatch: " + bestMatch + ", width: " + w + ", height: " + h);
-                  }
-                }
-                Log.d(TAG, "Calculated picture width: " + w + ", height: " + h);
-              }
-              */
+
               Camera.Parameters params = camera.getParameters();
               w = params.getPreviewSize().width;
               h = params.getPreviewSize().height;
@@ -389,11 +480,11 @@ public class CameraActivity extends Fragment {
               byte[] bytes = mPreview.getFramePicture(data, camera, w, h, quality); // raw bytes from preview
               final Bitmap pic = BitmapFactory.decodeByteArray(bytes, 0, bytes.length); // Bitmap from preview
 
-              /*
+
               //scale down
-              float scale = (float) pictureView.getWidth() / (float) pic.getWidth();
-              Bitmap scaledBitmap = Bitmap.createScaledBitmap(pic, (int) (pic.getWidth() * scale), (int) (pic.getHeight() * scale), false);
-              */
+              //float scale = (float) pictureView.getWidth() / (float) pic.getWidth();
+              //Bitmap scaledBitmap = Bitmap.createScaledBitmap(pic, (int) (pic.getWidth() * scale), (int) (pic.getHeight() * scale), false);
+
 
               final Matrix matrix = new Matrix();
               if (cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
@@ -403,23 +494,23 @@ public class CameraActivity extends Fragment {
               Log.d(TAG, "preRotate " + mPreview.getDisplayOrientation() + "deg");
               matrix.postRotate(mPreview.getDisplayOrientation());
 
-              /*
-              final Bitmap fixedPic = Bitmap.createBitmap(scaledBitmap, 0, 0, scaledBitmap.getWidth(), scaledBitmap.getHeight(), matrix, false);
-              final Rect rect = new Rect(mPreview.mSurfaceView.getLeft(), mPreview.mSurfaceView.getTop(), mPreview.mSurfaceView.getRight(), mPreview.mSurfaceView.getBottom());
-              */
+
+              // final Bitmap fixedPic = Bitmap.createBitmap(scaledBitmap, 0, 0, scaledBitmap.getWidth(), scaledBitmap.getHeight(), matrix, false);
+              // final Rect rect = new Rect(mPreview.mSurfaceView.getLeft(), mPreview.mSurfaceView.getTop(), mPreview.mSurfaceView.getRight(), mPreview.mSurfaceView.getBottom());
+
 
               Log.d(TAG, mPreview.mSurfaceView.getLeft() + " " + mPreview.mSurfaceView.getTop() + " " + mPreview.mSurfaceView.getRight() + " " + mPreview.mSurfaceView.getBottom());
 
               getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                  /*
-                  pictureView.setImageBitmap(fixedPic);
-                  pictureView.layout(rect.left, rect.top, rect.right, rect.bottom);
 
-                  Bitmap finalPic = pic;
-                  Bitmap originalPicture = Bitmap.createBitmap(finalPic, 0, 0, (int) (finalPic.getWidth()), (int) (finalPic.getHeight()), matrix, false);
-                  */
+                  //pictureView.setImageBitmap(fixedPic);
+                  //pictureView.layout(rect.left, rect.top, rect.right, rect.bottom);
+
+                  //Bitmap finalPic = pic;
+                  //Bitmap originalPicture = Bitmap.createBitmap(finalPic, 0, 0, (int) (finalPic.getWidth()), (int) (finalPic.getHeight()), matrix, false);
+
 
                   Bitmap originalPicture = Bitmap.createBitmap(pic, 0, 0, (int) (pic.getWidth()), (int) (pic.getHeight()), matrix, false);
 
@@ -431,7 +522,7 @@ public class CameraActivity extends Fragment {
             }
           }.start();
         }
-      });
+      }); */
     } else {
       canTakePicture = true;
     }


### PR DESCRIPTION
based on explanation on http://ibuzzlog.blogspot.nl/2012/08/how-to-use-camera-in-android.html, code on https://github.com/ikkiChung/MyCamera/

instead of taking a copy of a preview frame, takePicture should take an actual picture. This is done with  Camera.takePicture which takes 3 callbacks:
mCamera.takePicture(shutterCallback, rawPictureCallback, jpegPictureCallback);

Only the jpegPictureCallback is used here.

Before calling Camera.takePicture, the system should set the appropriate Camera parameters.

This implementation chooses the picture resolution as follows:
1. find the supportedPictureSize that has the same aspect ratio as the preview 
2. if passed in width and height are 0, the select the highest supported resolution that also is closest to the preview aspect ratio
3. if passed in width and height are not 0, then select supportedPictureSize that has preview aspect ratio and width/height closest to the passed in width / height

The plugin now behaves slightly differently when a picture is taken:
* shutter sound when takePicture is called
* camera preview stops until camera restarted (should mCamera.startPreview() not work?)
* resulting image may have larger resolution, but always tries to be close to preview aspect ratio

Tested on several resolutions and orientations

Todo?
- (re-)apply effects?
- insert focusCallback so that picture is only taken when focussed (see links above)
- remove now unused functions

