### PR TITLE
restoring default system shutter sound, removing unecessary stop/startPreview

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -415,8 +415,8 @@ public class CameraActivity extends Fragment {
             size.height = supportedSize.height;
           }
         } else {
-          // check if this pictureSize closer to width/height
-          if (Math.abs(width - supportedSize.width) * Math.abs(height - supportedSize.height) < Math.abs(width - size.width) * Math.abs(height - size.height)) {
+          // check if this pictureSize closer to requested width and height
+          if (Math.abs(width * height - supportedSize.width * supportedSize.height) < Math.abs(width * height - size.width * size.height)) {
             size.width = supportedSize.width;
             size.height = supportedSize.height;
           }

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -340,12 +340,9 @@ public class CameraActivity extends Fragment {
     return Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(), matrix, true);
   }
 
-  ShutterCallback shutterCallback = new ShutterCallback()
-	{
+  ShutterCallback shutterCallback = new ShutterCallback(){
 		 public void onShutter()
-		 {
-			 // do nothing, availabilty of this callback causes default system
-       // shutter sound to work
+			 // do nothing, availabilty of this callback causes default system shutter sound to work
 		 }
 	};
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -217,9 +217,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
 
     try {
-      DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
-      int width = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, args.getInt(0), metrics);
-      int height = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, args.getInt(1), metrics);
+      int width = args.getInt(0);
+      int height = args.getInt(1);
       int quality = args.getInt(2);
       fragment.takePicture(width, height, quality);
 


### PR DESCRIPTION
On Android, a picture taken should produce the default system defined shutter sound. For some reason this sound is triggered only if the shutterCallback is upplied in Camera.takePicture(shutterCallback, ...)

stopPreview() in takePicture() causes problems in some devices, so the call is removed including the corresponding startPreview() in jpegPictureCallback