### PR TITLE
Android: added exception and error handling if picture too large

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -48,6 +48,7 @@ public class CameraActivity extends Fragment {
 
   public interface CameraPreviewListener {
     void onPictureTaken(String originalPicture);
+    void onPictureTakenError(String message);
   }
 
   private CameraPreviewListener eventListener;
@@ -358,12 +359,17 @@ public class CameraActivity extends Fragment {
         byte[] byteArray = outputStream.toByteArray();
         String encodedImage = Base64.encodeToString(byteArray, Base64.NO_WRAP);
         eventListener.onPictureTaken(encodedImage);
+        Log.d(TAG, "CameraPreview pictureTakenHandler called back");
+      } catch (OutOfMemoryError e) {
+        // most likely failed to allocate memory for rotateBitmap
+        Log.d(TAG, "CameraPreview OutOfMemoryError");
+        // failed to allocate memory
+        eventListener.onPictureTakenError("Picture too large (memory)");
+      } catch (Exception e) {
+        Log.d(TAG, "CameraPreview onPictureTaken general exception");
+      } finally {
         canTakePicture = true;
         mCamera.startPreview();
-        Log.d(TAG, "CameraPreview pictureTakenHandler called back");
-      } catch (Exception e) {
-        Log.d(TAG, "CameraPreview exception");
-        e.printStackTrace();
       }
     }
   };

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -239,6 +239,11 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     takePictureCallbackContext.sendPluginResult(pluginResult);
   }
 
+  public void onPictureTakenError(String message) {
+    Log.d(TAG, "CameraPreview onPictureTakenError");
+    takePictureCallbackContext.error(message);
+  }
+
   private boolean setColorEffect(final JSONArray args, CallbackContext callbackContext) {
     if(fragment == null){
       callbackContext.error("No preview");


### PR DESCRIPTION
added exception handling and callback to errorCallback in:

CameraPreview.takePicture(options, successCallback, errorCallback)

An errorMessage (string) is passed into the errorCallback  

function errorCallback(errorMessage) {
}