### PR TITLE
fix ios flash command

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -138,7 +138,7 @@
   NSLog(@"Flash Mode");
   CDVPluginResult *pluginResult;
 
-  NSInteger flashMode = [command.arguments objectAtIndex:0];
+  NSInteger flashMode = [[command.arguments objectAtIndex:0] unsignedIntegerValue];
 
   if (self.sessionManager != nil) {
     [self.sessionManager setFlashMode:flashMode];


### PR DESCRIPTION
This fixes the set flash mode command for ios.

The command arguments were not casted to int.