### PR TITLE
add zoom in iphone. fix flash mode. add tap to focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
 These are some features that are currently Android only, however we would love to see PR's for this functionality in iOS.
 
 <ul>
-  <li>Zoom</li>
-  <li>Auto focus</li>
   <li>Torch flash mode</li>
+</ul>
+
+### iOS only features
+
+These are some features that are currently iOS only, however we would love to see PR's for this functionality in Android.
+
+<ul>
+  <li>Tap to focus</li>
 </ul>
 
 # Installation
@@ -190,6 +196,16 @@ CameraPreview.getSupportedPictureSizes(function(dimensions){
     console.log(dimension.width + 'x' + dimension.height);
   });
 });
+```
+
+### tapToFocus(xPoint, yPoint, [successCallback, errorCallback])
+
+<info>Set specific focus point. Note, this assumes the camera is full-screen.</info><br/>
+
+```javascript
+let xPoint = event.x;
+let yPoint = event.y
+CameraPreview.tapToFocus(xPoint, yPoint);
 ```
 
 # IOS Quirks

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -12,11 +12,13 @@
 - (void) showCamera:(CDVInvokedUrlCommand*)command;
 - (void) hideCamera:(CDVInvokedUrlCommand*)command;
 - (void) setFlashMode:(CDVInvokedUrlCommand*)command;
+- (void) setZoom:(CDVInvokedUrlCommand*)command;
 - (void) setPreviewSize: (CDVInvokedUrlCommand*)command;
 - (void) switchCamera:(CDVInvokedUrlCommand*)command;
 - (void) takePicture:(CDVInvokedUrlCommand*)command;
 - (void) setColorEffect:(CDVInvokedUrlCommand*)command;
 - (void) getSupportedPictureSizes:(CDVInvokedUrlCommand*)command;
+- (void) tapToFocus:(CDVInvokedUrlCommand*)command;
 
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(int) quality;
 - (void) invokeTakePicture;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -150,6 +150,22 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) setZoom:(CDVInvokedUrlCommand*)command {
+  NSLog(@"Zoom");
+  CDVPluginResult *pluginResult;
+
+  CGFloat desiredZoomFactor = [[command.arguments objectAtIndex:0] floatValue];
+
+  if (self.sessionManager != nil) {
+    [self.sessionManager setZoom:desiredZoomFactor];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not not zoomed"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) takePicture:(CDVInvokedUrlCommand*)command {
   NSLog(@"takePicture");
   CDVPluginResult *pluginResult;
@@ -209,26 +225,26 @@
 }
 
 - (void) setPreviewSize: (CDVInvokedUrlCommand*)command {
-    
+
     CDVPluginResult *pluginResult;
-    
+
     if (self.sessionManager == nil) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera did not start!"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
-    
+
     if (command.arguments.count > 1) {
         CGFloat width = (CGFloat)[command.arguments[0] floatValue];
         CGFloat height = (CGFloat)[command.arguments[1] floatValue];
-        
+
         self.cameraRenderController.view.frame = CGRectMake(0, 0, width, height);
-        
+
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid number of parameters"];
     }
-    
+
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
@@ -276,6 +292,23 @@
   }
 
   return base64Image;
+}
+
+- (void) tapToFocus:(CDVInvokedUrlCommand*)command {
+  NSLog(@"tapToFocus");
+  CDVPluginResult *pluginResult;
+
+  CGFloat xPoint = [[command.arguments objectAtIndex:0] floatValue];
+  CGFloat yPoint = [[command.arguments objectAtIndex:1] floatValue];
+
+  if (self.sessionManager != nil) {
+    [self.sessionManager tapToFocus:xPoint yPoint:yPoint];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not tapped to focus"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (double)radiansFromUIImageOrientation:(UIImageOrientation)orientation {
@@ -398,7 +431,7 @@
 
         double radians = [self radiansFromUIImageOrientation:resultImage.imageOrientation];
         CGImageRef resultFinalImage = [self CGImageRotated:finalImage withRadians:radians];
-        
+
         CGImageRelease(finalImage); // release CGImageRef to remove memory leaks
 
         NSString *base64Image = [self getBase64Image:resultFinalImage withQuality:quality];

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -8,7 +8,9 @@
 - (void) setupSession:(NSString *)defaultCamera;
 - (void) switchCamera;
 - (void) setFlashMode:(NSInteger)flashMode;
+- (void) setZoom:(CGFloat)desiredZoomFactor;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
+- (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 
 @property (atomic) CIFilter *ciFilter;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -99,6 +99,7 @@
       }
 
       [self updateOrientation:[self getCurrentOrientation]];
+      self.device = videoDevice;
   });
 }
 
@@ -188,6 +189,61 @@
     } else {
       errMsg = @"This device has no flash";
     }
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (void)setZoom:(CGFloat)desiredZoomFactor {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    [self.device lockForConfiguration:nil];
+
+    self.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, self.device.activeFormat.videoMaxZoomFactor));
+
+    [self.device setVideoZoomFactor:self.videoZoomFactor];
+    [self.device unlockForConfiguration];
+    NSLog(@"%zd zoom factor set", self.videoZoomFactor);
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    [self.device lockForConfiguration:nil];
+
+    CGRect screenRect = [[UIScreen mainScreen] bounds];
+    CGFloat screenWidth = screenRect.size.width;
+    CGFloat screenHeight = screenRect.size.height;
+    CGFloat focus_x = xPoint/screenWidth;
+    CGFloat focus_y = yPoint/screenHeight;
+
+    if ([self.device isFocusModeSupported:AVCaptureExposureModeAutoExpose]){
+      [self.device setFocusPointOfInterest:CGPointMake(focus_x,focus_y)];
+      [self.device setFocusMode:AVCaptureFocusModeAutoFocus];
+    }
+    if ([self.device isExposureModeSupported:AVCaptureExposureModeAutoExpose]){
+      [self.device setExposurePointOfInterest:CGPointMake(focus_x,focus_y)];
+      [self.device setExposureMode:AVCaptureExposureModeAutoExpose];
+    }
+
+    [self.device unlockForConfiguration];
   } else {
     errMsg = @"Session is not started";
   }

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -74,7 +74,7 @@ CameraPreview.setColorEffect = function(effect, onSuccess, onError){
 
 CameraPreview.setZoom = function(zoom, onSuccess, onError){
   exec(onSuccess, onError, PLUGIN_NAME, "setZoom", [zoom]);
-}
+};
 
 CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError){
   dimensions = dimensions || {};
@@ -82,7 +82,7 @@ CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError){
   dimensions.height = dimensions.height || window.screen.height;
 
   return exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
-}
+};
 
 CameraPreview.getSupportedPictureSizes = function(onSuccess, onError){
   exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
@@ -103,6 +103,10 @@ CameraPreview.setFlashMode = function(flashMode, onSuccess, onError) {
   }
 
   exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
+};
+
+CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError){
+  exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
 };
 
 module.exports = CameraPreview;


### PR DESCRIPTION
For ios, added zoom, fixed flash, and added touch to focus. Note that this plugin already had autofocus from iOS, so I removed that line from the README.

A few things to note:

- Setting flash mode once the camera was initialized only worked if `switchCamera` was called prior to that. This was because `setFlashMode` uses `self.device`, but `self.device` was only defined in the `switchCamera` method. So if the user never called `switchCamera`, `self.device` wasn't defined. I added `self.device = videoDevice;` on line 102 in the `setupSession` method.

- Setting the zoom number directly changes to the desired zoom. There is no smooth transition. This works well on pinch zoom, when the user will be calling this method on very tiny increments many times. If we want to make it a smooth transition option, down the line we can use the `ramp` method. So something like this:
```
[self.device rampToVideoZoomFactor:self.videoZoomFactor withRate:6.0];
```

- Not sure what git is thinking with `src/ios/CameraPreview.m` . The only changes in that file were the 2 methods I added: `setZoom` and `tapToFocus`. Don't know why git thinks I changed the whole file. Doesn't even look like its a tabs vs spaces issue or indent-size issue.

- For tap to focus, it assumes that the camera takes up the entire screen.