### PR TITLE
Refactor android camerapreview file

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -334,19 +334,19 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
     switch(mode) {
       case 0:
-        params.setFlashMode(params.FLASH_MODE_OFF);
+        params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
         break;
 
       case 1:
-        params.setFlashMode(params.FLASH_MODE_ON);
+        params.setFlashMode(Camera.Parameters.FLASH_MODE_ON);
         break;
 
       case 2:
-        params.setFlashMode(params.FLASH_MODE_AUTO);
+        params.setFlashMode(Camera.Parameters.FLASH_MODE_AUTO);
         break;
 
       case 3:
-        params.setFlashMode(params.FLASH_MODE_TORCH);
+        params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
         break;
     }
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -121,7 +121,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
             jsonSize.put("height", new Integer(h));
             jsonSize.put("width", new Integer(w));
           }
-          catch(Exception e){
+          catch(JSONException e){
             e.printStackTrace();
           }
           sizes.put(jsonSize);

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -104,37 +104,59 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
   }
 
+  private boolean hasView(CallbackContext callbackContext) {
+    if(fragment == null) {
+      callbackContext.error("No preview");
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean hasCamera(CallbackContext callbackContext) {
+    if(this.hasView(callbackContext) == false){
+      return false;
+    }
+
+    if(fragment.getCamera() == null) {
+      callbackContext.error("No Camera");
+      return false;
+    }
+
+    return true;
+  }
+
   private boolean getSupportedPictureSizes(CallbackContext callbackContext) {
+    if(this.hasCamera(callbackContext) == false){
+      return false;
+    }
+
     List<Camera.Size> supportedSizes;
     Camera camera = fragment.getCamera();
 
-    if (camera != null) {
-      supportedSizes = camera.getParameters().getSupportedPictureSizes();
-      if (supportedSizes != null) {
-        JSONArray sizes = new JSONArray();
-        for (int i=0; i<supportedSizes.size(); i++) {
-          Camera.Size size = supportedSizes.get(i);
-          int h = size.height;
-          int w = size.width;
-          JSONObject jsonSize = new JSONObject();
-          try {
-            jsonSize.put("height", new Integer(h));
-            jsonSize.put("width", new Integer(w));
-          }
-          catch(JSONException e){
-            e.printStackTrace();
-          }
-          sizes.put(jsonSize);
+    supportedSizes = camera.getParameters().getSupportedPictureSizes();
+    if (supportedSizes != null) {
+      JSONArray sizes = new JSONArray();
+      for (int i=0; i<supportedSizes.size(); i++) {
+        Camera.Size size = supportedSizes.get(i);
+        int h = size.height;
+        int w = size.width;
+        JSONObject jsonSize = new JSONObject();
+        try {
+          jsonSize.put("height", new Integer(h));
+          jsonSize.put("width", new Integer(w));
         }
-        callbackContext.success(sizes);
-        return true;
+        catch(JSONException e){
+          e.printStackTrace();
+        }
+        sizes.put(jsonSize);
       }
-      callbackContext.error("Camera Parameters access error");
-      return false;
+      callbackContext.success(sizes);
+      return true;
     }
-    callbackContext.error("Camera needs to be started first");
-    return false;
 
+    callbackContext.error("Camera Parameters access error");
+    return false;
   }
 
   private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, CallbackContext callbackContext) {
@@ -203,8 +225,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean takePicture(int width, int height, int quality, CallbackContext callbackContext) {
-    if(fragment == null){
-      callbackContext.error("No preview");
+    if(this.hasView(callbackContext) == false){
       return false;
     }
 
@@ -232,17 +253,11 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean setColorEffect(String effect, CallbackContext callbackContext) {
-    if(fragment == null){
-      callbackContext.error("No preview");
+    if(this.hasCamera(callbackContext) == false){
       return false;
     }
 
     Camera camera = fragment.getCamera();
-    if (camera == null){
-      callbackContext.error("No camera");
-      return true;
-    }
-
     Camera.Parameters params = camera.getParameters();
 
     if (effect.equals("aqua")) {
@@ -266,28 +281,23 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
 
     fragment.setCameraParameters(params);
+
     callbackContext.success(effect);
     return true;
   }
 
   private boolean setZoom(int zoom, CallbackContext callbackContext) {
-
-    if (fragment == null) {
-      callbackContext.error("No preview");
+    if(this.hasCamera(callbackContext) == false){
       return false;
     }
 
     Camera camera = fragment.getCamera();
-    if (camera == null) {
-      callbackContext.error("No camera");
-      return false;
-    }
-
     Camera.Parameters params = camera.getParameters();
 
     if (camera.getParameters().isZoomSupported()) {
       params.setZoom(zoom);
       fragment.setCameraParameters(params);
+
       callbackContext.success(zoom);
       return true;
     } else {
@@ -297,17 +307,12 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean setPreviewSize(int width, int height, CallbackContext callbackContext) {
-    if (fragment == null) {
-      callbackContext.error("No preview");
+
+    if(this.hasCamera(callbackContext) == false){
       return false;
     }
 
     Camera camera = fragment.getCamera();
-    if (camera == null) {
-      callbackContext.error("No camera");
-      return false;
-    }
-
     Camera.Parameters params = camera.getParameters();
 
     params.setPreviewSize(width, height);
@@ -319,17 +324,11 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean setFlashMode(int mode, CallbackContext callbackContext) {
-    if (fragment == null) {
-      callbackContext.error("No preview");
+    if(this.hasCamera(callbackContext) == false){
       return false;
     }
 
     Camera camera = fragment.getCamera();
-    if (camera == null) {
-      callbackContext.error("No camera");
-      return false;
-    }
-
     Camera.Parameters params = camera.getParameters();
 
     switch(mode) {
@@ -357,8 +356,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean stopCamera(CallbackContext callbackContext) {
-    if(fragment == null){
-      callbackContext.error("No preview");
+    if(this.hasView(callbackContext) == false){
       return false;
     }
 
@@ -373,8 +371,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
   private boolean showCamera(CallbackContext callbackContext) {
-    if(fragment == null){
-      callbackContext.error("No preview");
+    if(this.hasView(callbackContext) == false){
       return false;
     }
 
@@ -386,9 +383,9 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     callbackContext.success();
     return true;
   }
+
   private boolean hideCamera(CallbackContext callbackContext) {
-    if(fragment == null) {
-      callbackContext.error("No preview");
+    if(this.hasView(callbackContext) == false){
       return false;
     }
 
@@ -400,12 +397,14 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     callbackContext.success();
     return true;
   }
+
   private boolean switchCamera(CallbackContext callbackContext) {
-    if(fragment == null){
-      callbackContext.error("No preview");
+    if(this.hasView(callbackContext) == false){
       return false;
     }
+
     fragment.switchCamera();
+
     callbackContext.success();
     return true;
   }

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -23,24 +23,25 @@ import java.util.Arrays;
 
 public class CameraPreview extends CordovaPlugin implements CameraActivity.CameraPreviewListener {
 
-  private final String TAG = "CameraPreview";
-  private final String setColorEffectAction = "setColorEffect";
-  private final String setZoomAction = "setZoom";
-  private final String setFlashModeAction = "setFlashMode";
-  private final String startCameraAction = "startCamera";
-  private final String stopCameraAction = "stopCamera";
-  private final String previewSizeAction = "setPreviewSize";
-  private final String switchCameraAction = "switchCamera";
-  private final String takePictureAction = "takePicture";
-  private final String showCameraAction = "showCamera";
-  private final String hideCameraAction = "hideCamera";
-  private final String getSupportedPictureSizesAction = "getSupportedPictureSizes";
+  private static final String TAG = "CameraPreview";
 
-  private final String [] permissions = {
+  private static final String COLOR_EFFECT_ACTION = "setColorEffect";
+  private static final String ZOOM_ACTION = "setZoom";
+  private static final String FLASH_MODE_ACTION = "setFlashMode";
+  private static final String START_CAMERA_ACTION = "startCamera";
+  private static final String STOP_CAMERA_ACTION = "stopCamera";
+  private static final String PREVIEW_SIZE_ACTION = "setPreviewSize";
+  private static final String SWITCH_CAMERA_ACTION = "switchCamera";
+  private static final String TAKE_PICTURE_ACTION = "takePicture";
+  private static final String SHOW_CAMERA_ACTION = "showCamera";
+  private static final String HIDE_CAMERA_ACTION = "hideCamera";
+  private static final String SUPPORTED_PICTURE_SIZES_ACTION = "getSupportedPictureSizes";
+
+  private static final int CAM_REQ_CODE = 0;
+
+  private static final String [] permissions = {
     Manifest.permission.CAMERA
   };
-
-  private final int permissionsReqId = 0;
 
   private CameraActivity fragment;
   private CallbackContext takePictureCallbackContext;
@@ -57,33 +58,33 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   @Override
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
 
-    if (startCameraAction.equals(action)) {
+    if (START_CAMERA_ACTION.equals(action)) {
       if (cordova.hasPermission(permissions[0])) {
         return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), callbackContext);
       } else {
         this.execCallback = callbackContext;
         this.execArgs = args;
-        cordova.requestPermissions(this, 0, permissions);
+        cordova.requestPermissions(this, CAM_REQ_CODE, permissions);
       }
-    } else if (takePictureAction.equals(action)) {
+    } else if (TAKE_PICTURE_ACTION.equals(action)) {
       return takePicture(args.getInt(0), args.getInt(1), args.getInt(2), callbackContext);
-    } else if (setColorEffectAction.equals(action)) {
+    } else if (COLOR_EFFECT_ACTION.equals(action)) {
       return setColorEffect(args.getString(0), callbackContext);
-    } else if (setZoomAction.equals(action)) {
+    } else if (ZOOM_ACTION.equals(action)) {
       return setZoom(args.getInt(0), callbackContext);
-    } else if (previewSizeAction.equals(action)) {
+    } else if (PREVIEW_SIZE_ACTION.equals(action)) {
       return setPreviewSize(args.getInt(0), args.getInt(1), callbackContext);
-    } else if (setFlashModeAction.equals(action)) {
+    } else if (FLASH_MODE_ACTION.equals(action)) {
       return setFlashMode(args.getInt(0), callbackContext);
-    } else if (stopCameraAction.equals(action)){
+    } else if (STOP_CAMERA_ACTION.equals(action)){
       return stopCamera(callbackContext);
-    } else if (hideCameraAction.equals(action)) {
+    } else if (HIDE_CAMERA_ACTION.equals(action)) {
       return hideCamera(callbackContext);
-    } else if (showCameraAction.equals(action)) {
+    } else if (SHOW_CAMERA_ACTION.equals(action)) {
       return showCamera(callbackContext);
-    } else if (switchCameraAction.equals(action)) {
+    } else if (SWITCH_CAMERA_ACTION.equals(action)) {
       return switchCamera(callbackContext);
-    } else if (getSupportedPictureSizesAction.equals(action)) {
+    } else if (SUPPORTED_PICTURE_SIZES_ACTION.equals(action)) {
       return getSupportedPictureSizes(callbackContext);
     }
 
@@ -98,7 +99,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
         return;
       }
     }
-    if (requestCode == permissionsReqId) {
+    if (requestCode == CAM_REQ_CODE) {
       startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execCallback);
     }
   }

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -128,7 +128,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean getSupportedPictureSizes(CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
-      return false;
+      return true;
     }
 
     List<Camera.Size> supportedSizes;
@@ -156,14 +156,14 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
 
     callbackContext.error("Camera Parameters access error");
-    return false;
+    return true;
   }
 
   private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
     if (fragment != null) {
       callbackContext.error("Camera already started");
-      return false;
+      return true;
     }
 
     final float opacity = Float.parseFloat(alpha);
@@ -226,7 +226,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean takePicture(int width, int height, int quality, CallbackContext callbackContext) {
     if(this.hasView(callbackContext) == false){
-      return false;
+      return true;
     }
 
     takePictureCallbackContext = callbackContext;
@@ -254,7 +254,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean setColorEffect(String effect, CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
-      return false;
+      return true;
     }
 
     Camera camera = fragment.getCamera();
@@ -288,7 +288,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean setZoom(int zoom, CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
-      return false;
+      return true;
     }
 
     Camera camera = fragment.getCamera();
@@ -299,17 +299,16 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       fragment.setCameraParameters(params);
 
       callbackContext.success(zoom);
-      return true;
     } else {
       callbackContext.error("Zoom not supported");
-      return false;
     }
+
+    return true;
   }
 
   private boolean setPreviewSize(int width, int height, CallbackContext callbackContext) {
-
     if(this.hasCamera(callbackContext) == false){
-      return false;
+      return true;
     }
 
     Camera camera = fragment.getCamera();
@@ -325,7 +324,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean setFlashMode(int mode, CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
-      return false;
+      return true;
     }
 
     Camera camera = fragment.getCamera();
@@ -357,7 +356,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean stopCamera(CallbackContext callbackContext) {
     if(this.hasView(callbackContext) == false){
-      return false;
+      return true;
     }
 
     FragmentManager fragmentManager = cordova.getActivity().getFragmentManager();
@@ -372,7 +371,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean showCamera(CallbackContext callbackContext) {
     if(this.hasView(callbackContext) == false){
-      return false;
+      return true;
     }
 
     FragmentManager fragmentManager = cordova.getActivity().getFragmentManager();
@@ -386,7 +385,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean hideCamera(CallbackContext callbackContext) {
     if(this.hasView(callbackContext) == false){
-      return false;
+      return true;
     }
 
     FragmentManager fragmentManager = cordova.getActivity().getFragmentManager();
@@ -400,7 +399,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private boolean switchCamera(CallbackContext callbackContext) {
     if(this.hasView(callbackContext) == false){
-      return false;
+      return true;
     }
 
     fragment.switchCamera();


### PR DESCRIPTION
I fixed a few thing in the android file:

1. Only parse the command arguments in `execute()`.
This let me remove all the `try {} catch {}` blocks that were everywhere to catch `JSONException` as this is handled by `execute(...) throws JSONException`

2. Capitalize contants
3. Only catch appropriate exceptions
4. Use static constants for flash mode
5. Remove duplicate code (check camera and view)
6. Fix the 'Attempted to send a second callback for ID' warning error
If `execute()` returns false, cordova throws a `INVALID_ACTION` error causing the error messages to stack and cause the error. 