### PR TITLE
iOS: remove view reference in controller

### DIFF
--- a/src/ios/CameraRenderController.h
+++ b/src/ios/CameraRenderController.h
@@ -19,7 +19,6 @@
   CVOpenGLESTextureRef _lumaTexture;
 }
 
-@property (nonatomic) GLKView *view;
 @property (nonatomic) CameraSessionManager *sessionManager;
 @property (nonatomic) CIContext *ciContext;
 @property (nonatomic) CIImage *latestFrame;


### PR DESCRIPTION
The reference to `view` is already inherited from `UIView​Controller`.
https://developer.apple.com/reference/uikit/uiviewcontroller/1621460-view

It throws a warning when compiling.