### PR TITLE
fix switching camera on android - only call `open` once. get correct …

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -281,13 +281,6 @@ public class CameraActivity extends Fragment {
         mCamera = null;
       }
 
-      // Acquire the next camera and request Preview to reconfigure parameters.
-      mCamera = Camera.open((cameraCurrentlyLocked + 1) % numberOfCameras);
-
-      if (cameraParameters != null) {
-        mCamera.setParameters(cameraParameters);
-      }
-
       Log.d(TAG, "cameraCurrentlyLocked := " + Integer.toString(cameraCurrentlyLocked));
       try {
         cameraCurrentlyLocked = (cameraCurrentlyLocked + 1) % numberOfCameras;
@@ -296,6 +289,7 @@ public class CameraActivity extends Fragment {
         Log.d(TAG, exception.getMessage());
       }
 
+      // Acquire the next camera and request Preview to reconfigure parameters.
       mCamera = Camera.open(cameraCurrentlyLocked);
 
       if (cameraParameters != null) {

--- a/src/android/Preview.java
+++ b/src/android/Preview.java
@@ -132,8 +132,11 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback {
 
       Log.d("CameraPreview", "before setPreviewSize");
 
+      mSupportedPreviewSizes = parameters.getSupportedPreviewSizes();
+      mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, mSurfaceView.getWidth(), mSurfaceView.getHeight());
       parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
       Log.d(TAG, mPreviewSize.width + " " + mPreviewSize.height);
+
       camera.setParameters(parameters);
     } catch (IOException exception) {
       Log.e(TAG, exception.getMessage());


### PR DESCRIPTION
…previewsize for front/back

On Android, switching between the front and rear camera was broken.

Addresses this issue: https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/237

It was breaking in two places. First, in CameraActivity.java, we were calling `Camera.open` twice ( as well as `mCamera.setParameters` twice). However, after releasing a camera, you can only call `Camera.open` once. So the second time of calling `Camera.open` would throw an error. This was most likely introduced from the commit from 2months ago: https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/commit/16458153b08c2fa24d89d8248d5b25cd66ce4f5f

After fixing that, I noticed that on my particular Android device, starting on the back camera, then switching to the front didn't work. However, starting on the front and switching to the back does work. This was because on my device, the back camera `mSupportedPreviewSizes` contains all the `mSupportedPreviewSizes` of the front camera, plus a few extras. One of those extras was selected in the `Preview.java`'s `getOptimalPreviewSize` method. However, when switching to the front camera, that selected `previewSize` is not an option for the front camera. So an error would be thrown. Fix is to re-compute the optimal `previewSize` when switching cameras. (See `Preview.java`).