### PR TITLE
only set params on switchCamera if flashMode supported

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -294,7 +294,17 @@ public class CameraActivity extends Fragment {
 
       if (cameraParameters != null) {
         Log.d(TAG, "camera parameter not null");
-        mCamera.setParameters(cameraParameters);
+
+        // Check for flashMode as well to prevent error on frontward facing camera.
+        List<String> supportedFlashModesNewCamera = mCamera.getParameters().getSupportedFlashModes();
+        String currentFlashModePreviousCamera = cameraParameters.getFlashMode();
+        if (supportedFlashModesNewCamera != null && supportedFlashModesNewCamera.contains(currentFlashModePreviousCamera)) {
+          Log.d(TAG, "current flash mode supported on new camera. setting params");
+          mCamera.setParameters(cameraParameters);
+        } else {
+          Log.d(TAG, "current flash mode NOT supported on new camera");
+        }
+
       } else {
         Log.d(TAG, "camera parameter NULL");
       }


### PR DESCRIPTION
On Android, some devices/versions don't have flash on the frontward facing camera. For example, I'm using Android version 5.1.1 on a Nexus 5, and my phone does not have frontward facing flash.

However, when on the rear camera, and flash is turned on, and then switching cameras to the front camera, an error is thrown. This is because `cameraParameters` (on line 297) is from the old rear camera. The current `flashMode` on that camera is "on", or "off", or "auto", etc. However, for the front camera, no flashModes are supported (not even "off"). When on front camera, `mCamera.getParameters()supportedFlashModes` doesn't even return a list, it just returns `null`. So since the new front-camera doesn't support any flashModes, but the old rear-camera has a `flashMode` set, android will throw an error.

Fix is to only set the old `cameraParameters` on the new `mCamera` only when the new camera supports the current camera's flashMode.