### PR TITLE
New zoom and exposure features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
   <li>Set a custom alpha for the preview box.</li>
+  <li>get current zoom and maximum zoom factors</li>
+  <li>get and set exposure mode</li>
+  <li>get and set exposure compensation</li>
   <li>Maintain HTML interactivity.</li>
 </ul>
 
@@ -26,10 +29,6 @@ These are some features that are currently Android only, however we would love t
 
 <ul>
   <li>Torch flash mode</li>
-  <li>get current zoom</li>
-  <li>get max zoom</li>
-  <li>get and set auto-exposure lock</li>
-  <li>get and set exposure compensation</li>
 </ul>
 
 ### iOS only features
@@ -211,33 +210,32 @@ CameraPreview.getMaxZoom(function(maxZoom){
   console.log(maxZoom);
 });
 ```
-### getAutoExposureLock(cb, [errorCallback])
+### getExposureModes(cb, [errorCallback])
 
-<info>Get the auto-exposure lock flag. Returns "locked" if the the auto-exposure is currently locked, otherwhise "unlocked" is returned. Android only</info><br/>
-
-```javascript
-CameraPreview.getAutoExposureLock(function(autoExposureLock){
-  console.log(autoExposureLock);
-});
-```
-### setAutoExposureLock(lock, [successCallback, errorCallback])
-
-<info>Set the auto exposure lock flag. lock accepts a boolean. If lock is true, the auto-exposure will be locked. If lock is false, the auto-exposure will be unlocked. Android only</info><br/>
+<info>Returns an array with supported exposure modes. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
 
 ```javascript
-CameraPreview.setAutoExposureLock(true);
-```
-
-### getExposureCompensation(cb, [errorCallback])
-
-<info>Get the current exposure compensation. Returns an integer representing the current exposure compensation. Android only</info><br/>
-
-```javascript
-CameraPreview.getExposureCompensation(function(expoxureCompensation){
-  console.log(exposureCompensation);
+CameraPreview.getExposureModes(function(exposureModes){
+  console.log(exposureModes);
 });
 ```
 
+### getExposureMode(cb, [errorCallback])
+
+<info>Get the curent exposure mode of the device. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
+
+```javascript
+CameraPreview.getExposureMode(function(exposureMode){
+  console.log(exposureMode);
+});
+```
+### setExposureMode(exposureMode, [successCallback, errorCallback])
+
+<info>Set the exposure mode. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
+
+```javascript
+CameraPreview.setExposureMode(CameraPreview.EXPOSURE_MODE.CONTINUOUS);
+```
 ### getExposureCompensationRange(cb, [errorCallback])
 
 <info>Get the minimum and maximum exposure compensation. Returns an object containing min and max integers. Android only</info><br/>
@@ -246,6 +244,15 @@ CameraPreview.getExposureCompensation(function(expoxureCompensation){
 CameraPreview.getExposureCompensationRange(function(expoxureRange){
   console.log("min: " + exposureRange.min);
   console.log("max: " + exposureRange.max);
+});
+```
+### getExposureCompensation(cb, [errorCallback])
+
+<info>Get the current exposure compensation. Returns an integer representing the current exposure compensation. Android only</info><br/>
+
+```javascript
+CameraPreview.getExposureCompensation(function(expoxureCompensation){
+  console.log(exposureCompensation);
 });
 ```
 ### setExposureCompensation(exposureCompensation, [successCallback, errorCallback])
@@ -329,6 +336,21 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | SEPIA | string | sepia | |
 | SOLARIZE | string | solarize | Android Only |
 | WHITEBOARD | string | whiteboard | Android Only |
+
+<a name="camera_Settings.ExposureMode"></a>
+
+### EXPOSURE_MODE
+
+<info>Exposure mode settings:</info><br/>
+
+| Name | Type | Default | Note |
+| --- | --- | --- | --- |
+| AUTO | string | auto | IOS Only |
+| CONTINUOUS | string | continuous | |
+| CUSTOM | string | custom | |
+| LOCKED | string | custom | IOS Only |
+
+Note: Use AUTO to allow the device automatically adjusts the exposure once and then changes the exposure mode to LOCK.
 
 # IOS Quirks
 It is not possible to use your computers webcam during testing in the simulator, you must device test.

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | AUTO | string | auto | IOS Only |
 | CONTINUOUS | string | continuous | |
 | CUSTOM | string | custom | |
-| LOCKED | string | custom | IOS Only |
+| LOCK | string | lock | IOS Only |
 
 Note: Use AUTO to allow the device automatically adjusts the exposure once and then changes the exposure mode to LOCK.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
   <li>Start a camera preview from HTML code.</li>
   <li>Drag the preview box.</li>
   <li>Set camera color effect.</li>
+  <li>Set the flash mode</li>
+  <li>Get and set the camera zoom</li>
+  <li>Get and set the auto-exposure lock</li>
+  <li>Get and set the axposure compensation</li>
   <li>Send the preview box to back of the HTML content.</li>
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
@@ -26,6 +30,13 @@ These are some features that are currently Android only, however we would love t
 
 <ul>
   <li>Torch flash mode</li>
+  <li>getZoom() method</li>
+  <li>getMaxZoom() method</li>
+  <li>getAutoExposureLock() method</li>
+  <li>setAutoExposureLock() method</li>
+  <li>getExposureCompensation() method</li>
+  <li>setExposureCompensation() method</li>
+  <li>getExposureCompensationRange() method</li>
 </ul>
 
 ### iOS only features
@@ -186,6 +197,71 @@ CameraPreview.setColorEffect(CameraPreview.COLOR_EFFECT.NEGATIVE);
 
 ```javascript
 CameraPreview.setZoom(2);
+```
+
+### getZoom(cb, [errorCallback])
+
+<info>Get the current zoom level. Returns an integer representing the current zomm level. Android only</info><br/>
+
+```javascript
+CameraPreview.getZoom(function(currentZoom){
+  console.log(currentZoom);
+});
+```
+
+### getMaxZoom(cb, [errorCallback])
+
+<info>Get the maximum zoom level. Returns an integer representing the manimum zoom level. Android only</info><br/>
+
+```javascript
+CameraPreview.getMaxZoom(function(maxZoom){
+  console.log(maxZoom);
+});
+```
+### getAutoExposureLock(cb, [errorCallback])
+
+<info>Get the auto-exposure lock flag. Returns "locked" if the the auto-exposure is currently locked, otherwhise "unlocked" is returned. Android only</info><br/>
+
+```javascript
+CameraPreview.getAutoExposureLock(function(autoExposureLock){
+  console.log(autoExposureLock);
+});
+```
+### setAutoExposureLock(lock, [successCallback, errorCallback])
+
+<info>Set the auto exposure lock flag. lock accepts a boolean. If lock is true, the auto-exposure will be locked. If lock is false, the auto-exposure will be unlocked. Android only</info><br/>
+
+```javascript
+CameraPreview.setAutoExposureLock(true);
+```
+
+### getExposureCompensation(cb, [errorCallback])
+
+<info>Get the current exposure compensation. Returns an integer representing the current exposure compensation. Android only</info><br/>
+
+```javascript
+CameraPreview.getExposureCompensation(function(expoxureCompensation){
+  console.log(exposureCompensation);
+});
+```
+
+### getExposureCompensationRange(cb, [errorCallback])
+
+<info>Get the minimum and maximum exposure compensation. Returns an object containing min and max integers. Android only</info><br/>
+
+```javascript
+CameraPreview.getExposureCompensation(function(expoxureRange){
+  console.log("min: " + exposureRange.min);
+  console.log("max: " + exposureRange.max);
+});
+```
+### setExposureCompensation(exposureCompensation, [successCallback, errorCallback])
+
+<info>Set the exposure compensation. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it i set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it i set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation). Android only</info><br/>
+
+```javascript
+CameraPreview.setExposureCompensation(-2);
+CameraPreview.setExposureCompensation(3);
 ```
 
 ### setPreviewSize([dimensions, successCallback, errorCallback])

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ CameraPreview.setZoom(2);
 
 ### getZoom(cb, [errorCallback])
 
-<info>Get the current zoom level. Returns an integer representing the current zomm level. Android only</info><br/>
+<info>Get the current zoom level. Returns an integer representing the current zoom level. Android only</info><br/>
 
 ```javascript
 CameraPreview.getZoom(function(currentZoom){
@@ -250,7 +250,7 @@ CameraPreview.getExposureCompensationRange(function(expoxureRange){
 ```
 ### setExposureCompensation(exposureCompensation, [successCallback, errorCallback])
 
-<info>Set the exposure compensation. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it i set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it i set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation). Android only</info><br/>
+<info>Set the exposure compensation. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it is set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it is set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation). Android only</info><br/>
 
 ```javascript
 CameraPreview.setExposureCompensation(-2);

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | OFF | string | off |  |
 | ON | string | on |  |
 | AUTO | string | auto |  |
-| RED_EYE | string | red-eye |  |
+| RED_EYE | string | red-eye | Android Only |
 | TORCH | string | torch |  |
 
 <a name="camera_Settings.CameraDirection"></a>

--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
 
 ### Android only features
 
-These are some features that are currently Android only, however we would love to see PR's for this functionality in iOS.
-
-<ul>
-  <li>Torch flash mode</li>
-</ul>
+None
 
 ### iOS only features
 
@@ -306,7 +302,7 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | OFF | string | off |  |
 | ON | string | on |  |
 | AUTO | string | auto |  |
-| TORCH | string | torch | Android Only |
+| TORCH | string | torch |  |
 
 <a name="camera_Settings.CameraDirection"></a>
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
   <li>Start a camera preview from HTML code.</li>
   <li>Drag the preview box.</li>
   <li>Set camera color effect.</li>
-  <li>Set the flash mode</li>
-  <li>Get and set the camera zoom</li>
-  <li>Get and set the auto-exposure lock</li>
-  <li>Get and set the axposure compensation</li>
   <li>Send the preview box to back of the HTML content.</li>
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
@@ -30,13 +26,10 @@ These are some features that are currently Android only, however we would love t
 
 <ul>
   <li>Torch flash mode</li>
-  <li>getZoom() method</li>
-  <li>getMaxZoom() method</li>
-  <li>getAutoExposureLock() method</li>
-  <li>setAutoExposureLock() method</li>
-  <li>getExposureCompensation() method</li>
-  <li>setExposureCompensation() method</li>
-  <li>getExposureCompensationRange() method</li>
+  <li>get current zoom</li>
+  <li>get max zoom</li>
+  <li>get and set auto-exposure lock</li>
+  <li>get and set exposure compensation</li>
 </ul>
 
 ### iOS only features
@@ -250,7 +243,7 @@ CameraPreview.getExposureCompensation(function(expoxureCompensation){
 <info>Get the minimum and maximum exposure compensation. Returns an object containing min and max integers. Android only</info><br/>
 
 ```javascript
-CameraPreview.getExposureCompensation(function(expoxureRange){
+CameraPreview.getExposureCompensationRange(function(expoxureRange){
   console.log("min: " + exposureRange.min);
   console.log("max: " + exposureRange.max);
 });

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
 
 ### Android only features
 
-None
+<ul>
+  <li>RED_EYE flash mode do not have a corresponding API in IOS.</li>
+</ul>
 
 ### iOS only features
 
@@ -156,6 +158,18 @@ CameraPreview.takePicture({width:640, height:640, quality: 85}, function(base64P
 
 CameraPreview.takePicture(function(base64PictureData){
   /* code here */
+});
+```
+### getSupportedPictureSizes(cb, [errorCallback])
+
+<info>Get the flash modes supported by the device. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
+
+```javascript
+CameraPreview.getSupportedFlashModes(function(flashModes){
+  // note that the portrait version, width and height swapped, of these dimensions are also supported
+  flashModes.forEach(function(flashMode) {
+    console.log(flashMode + ', ');
+  });
 });
 ```
 
@@ -302,6 +316,7 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | OFF | string | off |  |
 | ON | string | on |  |
 | AUTO | string | auto |  |
+| RED_EYE | string | red-eye |  |
 | TORCH | string | torch |  |
 
 <a name="camera_Settings.CameraDirection"></a>

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -19,7 +19,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.util.List;
-import java.io.Console;
 import java.util.Arrays;
 
 public class CameraPreview extends CordovaPlugin implements CameraActivity.CameraPreviewListener {

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -38,8 +38,9 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   private static final String SHOW_CAMERA_ACTION = "showCamera";
   private static final String HIDE_CAMERA_ACTION = "hideCamera";
   private static final String SUPPORTED_PICTURE_SIZES_ACTION = "getSupportedPictureSizes";
-  private static final String GET_AUTOEXPOSURE_LOCK_ACTION = "getAutoExposureLock";
-  private static final String SET_AUTOEXPOSURE_LOCK_ACTION = "setAutoExposureLock";
+  private static final String GET_EXPOSURE_MODES_ACTION = "getExposureModes";
+  private static final String GET_EXPOSURE_MODE_ACTION = "getExposureMode";
+  private static final String SET_EXPOSURE_MODE_ACTION = "setExposureMode";
   private static final String GET_EXPOSURE_COMPENSATION_ACTION = "getExposureCompensation";
   private static final String SET_EXPOSURE_COMPENSATION_ACTION = "setExposureCompensation";
   private static final String GET_EXPOSURE_COMPENSATION_RANGE_ACTION = "getExposureCompensationRange";
@@ -97,10 +98,12 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       return switchCamera(callbackContext);
     } else if (SUPPORTED_PICTURE_SIZES_ACTION.equals(action)) {
       return getSupportedPictureSizes(callbackContext);
-    } else if (GET_AUTOEXPOSURE_LOCK_ACTION.equals(action)) {
-      return getAutoExposureLock(callbackContext);  
-    } else if (SET_AUTOEXPOSURE_LOCK_ACTION.equals(action)) {
-      return setAutoExposureLock(args.getBoolean(0), callbackContext);
+    } else if (GET_EXPOSURE_MODES_ACTION.equals(action)) {
+      return getExposureModes(callbackContext);  
+    } else if (GET_EXPOSURE_MODE_ACTION.equals(action)) {
+      return getExposureMode(callbackContext);  
+    } else if (SET_EXPOSURE_MODE_ACTION.equals(action)) {
+      return setExposureMode(args.getString(0), callbackContext);
     } else if (GET_EXPOSURE_COMPENSATION_ACTION.equals(action)) {
       return getExposureCompensation(callbackContext);
     } else if (SET_EXPOSURE_COMPENSATION_ACTION.equals(action)) {
@@ -307,7 +310,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getAutoExposureLock(CallbackContext callbackContext) {
+  private boolean getExposureModes(CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
       return true;
     }
@@ -315,22 +318,42 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Camera camera = fragment.getCamera();
     Camera.Parameters params = camera.getParameters();
 
-    String autoExposureLock;
-
     if (camera.getParameters().isAutoExposureLockSupported()) {
-      if (camera.getParameters().getAutoExposureLock()) {
-        autoExposureLock = "locked";   
-      } else {
-        autoExposureLock = "unlocked";    
-      }; 
-      callbackContext.success(autoExposureLock);
+ //     String[] exposureModes = {"lock", "unlock"};
+      JSONArray jsonExposureModes = new JSONArray();
+      jsonExposureModes.put(new String("continuous"));
+      jsonExposureModes.put(new String("custom"));  
+      callbackContext.success(jsonExposureModes);
     } else {
-      callbackContext.error("AutoExposureLock not supported");
+      callbackContext.error("Exposure modes not supported");
     }
     return true;
   }
 
-  private boolean setAutoExposureLock(boolean lock, CallbackContext callbackContext) {
+  private boolean getExposureMode(CallbackContext callbackContext) {
+    if(this.hasCamera(callbackContext) == false){
+      return true;
+    }
+
+    Camera camera = fragment.getCamera();
+    Camera.Parameters params = camera.getParameters();
+
+    String exposureMode;
+
+    if (camera.getParameters().isAutoExposureLockSupported()) {
+      if (camera.getParameters().getAutoExposureLock()) {
+        exposureMode = "continuous";   
+      } else {
+        exposureMode = "custom";    
+      }; 
+      callbackContext.success(exposureMode);
+    } else {
+      callbackContext.error("Exposure mode not supported");
+    }
+    return true;
+  }
+
+  private boolean setExposureMode(String exposureMode, CallbackContext callbackContext) {
     if(this.hasCamera(callbackContext) == false){
       return true;
     }
@@ -339,12 +362,11 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Camera.Parameters params = camera.getParameters();
 
     if (camera.getParameters().isAutoExposureLockSupported()) {
-      params.setAutoExposureLock(lock);
+      params.setAutoExposureLock("continuous".equals(exposureMode));
       fragment.setCameraParameters(params);
-
       callbackContext.success();
     } else {
-      callbackContext.error("AutoExposureLock not supported");
+      callbackContext.error("Exposure mode not supported");
     }
     return true;
   }

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -13,6 +13,14 @@
 - (void) hideCamera:(CDVInvokedUrlCommand*)command;
 - (void) setFlashMode:(CDVInvokedUrlCommand*)command;
 - (void) setZoom:(CDVInvokedUrlCommand*)command;
+- (void) getZoom:(CDVInvokedUrlCommand*)command;
+- (void) getMaxZoom:(CDVInvokedUrlCommand*)command;
+- (void) getExposureModes:(CDVInvokedUrlCommand*)command;
+- (void) getExposureMode:(CDVInvokedUrlCommand*)command;
+- (void) setExposureMode:(CDVInvokedUrlCommand*)command;
+- (void) getExposureCompensation:(CDVInvokedUrlCommand*)command;
+- (void) setExposureCompensation:(CDVInvokedUrlCommand*)command;
+- (void) getExposureCompensationRange:(CDVInvokedUrlCommand*)command;
 - (void) setPreviewSize: (CDVInvokedUrlCommand*)command;
 - (void) switchCamera:(CDVInvokedUrlCommand*)command;
 - (void) takePicture:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -26,6 +26,7 @@
 - (void) takePicture:(CDVInvokedUrlCommand*)command;
 - (void) setColorEffect:(CDVInvokedUrlCommand*)command;
 - (void) getSupportedPictureSizes:(CDVInvokedUrlCommand*)command;
+- (void) getSupportedFlashModes:(CDVInvokedUrlCommand*)command;
 - (void) tapToFocus:(CDVInvokedUrlCommand*)command;
 
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(int) quality;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -134,6 +134,19 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) getSupportedFlashModes:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSArray * flashModes = [self.sessionManager getFlashModes];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:flashModes];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Flash not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) setFlashMode:(CDVInvokedUrlCommand*)command {
   NSLog(@"Flash Mode");
   NSString *errMsg;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -180,6 +180,117 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) getZoom:(CDVInvokedUrlCommand*)command {
+  
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    CGFloat zoom = [self.sessionManager getZoom];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:zoom ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not zoomed"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getMaxZoom:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    CGFloat maxZoom = [self.sessionManager getMaxZoom];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:maxZoom ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not zoomed"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getExposureModes:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSArray * exposureModes = [self.sessionManager getExposureModes];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:exposureModes];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getExposureMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSString * exposureMode = [self.sessionManager getExposureMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:exposureMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) setExposureMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  NSString * exposureMode = [[command.arguments objectAtIndex:0] stringValue];
+  if (self.sessionManager != nil) {
+    [self.sessionManager setExposureMode:exposureMode];
+    NSString * exposureMode = [self.sessionManager getExposureMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:exposureMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+  }
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getExposureCompensationRange:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSArray * exposureRange = [self.sessionManager getExposureCompensationRange];
+    NSMutableDictionary *dimensions = [[NSMutableDictionary alloc] init];
+    [dimensions setValue:exposureRange[0] forKey:@"min"];
+    [dimensions setValue:exposureRange[1] forKey:@"max"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dimensions];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No session started"];
+  }
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getExposureCompensation:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    CGFloat exposureCompensation = [self.sessionManager getExposureCompensation];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:exposureCompensation ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) setExposureCompensation:(CDVInvokedUrlCommand*)command {
+  NSLog(@"Zoom");
+  CDVPluginResult *pluginResult;
+
+  CGFloat exposureCompensation = [[command.arguments objectAtIndex:0] floatValue];
+
+  if (self.sessionManager != nil) {
+    [self.sessionManager setExposureCompensation:exposureCompensation];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:exposureCompensation];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) takePicture:(CDVInvokedUrlCommand*)command {
   NSLog(@"takePicture");
   CDVPluginResult *pluginResult;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -146,8 +146,10 @@
       [self.sessionManager setFlashMode:AVCaptureFlashModeOff];
     } else if ([flashMode isEqual: @"on"]) {
       [self.sessionManager setFlashMode:AVCaptureFlashModeOn];
-    } else if ([flashMode isEqual: @"auto"]) {
+    } else if ([flashMode isEqual: @"auto"]) {  
       [self.sessionManager setFlashMode:AVCaptureFlashModeAuto];
+    } else if ([flashMode isEqual: @"torch"]) {
+      [self.sessionManager setTorchMode];  
     } else {
       errMsg = @"Flash Mode not supported";
     }

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -5,6 +5,7 @@
 
 - (CameraSessionManager *)init;
 - (NSArray *) getDeviceFormats;
+- (NSArray *) getFlashModes;
 - (void) setupSession:(NSString *)defaultCamera;
 - (void) switchCamera;
 - (void) setFlashMode:(NSInteger)flashMode;

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -9,6 +9,14 @@
 - (void) switchCamera;
 - (void) setFlashMode:(NSInteger)flashMode;
 - (void) setZoom:(CGFloat)desiredZoomFactor;
+- (CGFloat) getZoom;
+- (CGFloat) getMaxZoom;
+- (NSArray *) getExposureModes;
+- (NSString *) getExposureMode;
+- (NSString *) setExposureMode:(NSString *)exposureMode;
+- (NSArray *) getExposureCompensationRange;
+- (CGFloat) getExposureCompensation;
+- (void) setExposureCompensation:(CGFloat)exposureCompensation;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -19,6 +19,7 @@
 - (void) setExposureCompensation:(CGFloat)exposureCompensation;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
+- (void) setTorchMode;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 
 @property (atomic) CIFilter *ciFilter;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -204,12 +204,233 @@
   // check session is started
   if (self.session) {
     [self.device lockForConfiguration:nil];
-
     self.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, self.device.activeFormat.videoMaxZoomFactor));
 
     [self.device setVideoZoomFactor:self.videoZoomFactor];
     [self.device unlockForConfiguration];
     NSLog(@"%zd zoom factor set", self.videoZoomFactor);
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (CGFloat)getZoom {
+
+  NSString *errMsg;
+
+  // check session is started
+    
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    return videoDevice.videoZoomFactor;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (CGFloat)getMaxZoom {
+
+  NSString *errMsg;
+
+  // check session is started
+
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    return videoDevice.activeFormat.videoMaxZoomFactor;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (NSArray *)getExposureModes {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    NSMutableArray *exposureModes = [[NSMutableArray alloc] init];
+    if ([videoDevice isExposureModeSupported:0]) {
+      [exposureModes addObject:@"lock"];
+    };
+    if ([videoDevice isExposureModeSupported:1]) {
+      [exposureModes addObject:@"auto"];
+    };
+    if ([videoDevice isExposureModeSupported:2]) {
+      [exposureModes addObject:@"cotinuous"];
+    };
+    if ([videoDevice isExposureModeSupported:3]) {
+      [exposureModes addObject:@"custom"];
+    };
+    NSLog(@"%@", exposureModes);
+    return (NSArray *) exposureModes;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (NSString *) getExposureMode {
+
+  NSString *errMsg;
+  NSString *exposureMode;
+
+  // check session is started 
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    switch (videoDevice.exposureMode) {
+      case 0:
+          exposureMode = @"lock";
+        break;
+      case 1:
+        exposureMode = @"auto";
+        break;
+      case 2:
+        exposureMode = @"continuous";
+        break;  
+      case 3:
+        exposureMode = @"custom";
+        break;
+      default:
+        exposureMode = @"unsupported";
+        errMsg = @"Mode not supported";
+    }
+    return exposureMode;
+  } else {
+    errMsg = @"Session is not started";
+  }
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (NSString *) setExposureMode:(NSString *)exposureMode {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    [self.device lockForConfiguration:nil];
+    if ([exposureMode isEqual:@"lock"]) {
+      if ([videoDevice isExposureModeSupported:0]) {
+        videoDevice.exposureMode = 0;
+        return exposureMode;
+      } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+      };
+    } else if ([exposureMode isEqual:@"auto"]) {
+      if ([videoDevice isExposureModeSupported:1]) {
+        videoDevice.exposureMode = 1;
+        return exposureMode;
+    } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+      };
+    } else if ([exposureMode isEqual:@"continuous"]) {
+      if ([videoDevice isExposureModeSupported:2]) {
+        videoDevice.exposureMode = 2;
+        return exposureMode;
+      } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+      };  
+    } else if ([exposureMode isEqual:@"custom"]) {
+      if ([videoDevice isExposureModeSupported:3]) {
+        videoDevice.exposureMode = 3;
+        return exposureMode;
+      } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+      };
+    } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+    } 
+    [self.device unlockForConfiguration];
+  } else {
+    errMsg = @"Session is not started";
+    return @"ERR02";
+  }
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (NSArray *)getExposureCompensationRange {
+
+  NSString *errMsg;
+
+  // check session is started
+    
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    CGFloat maxExposureCompensation = videoDevice.maxExposureTargetBias;
+    CGFloat minExposureCompensation = videoDevice.minExposureTargetBias;
+    NSArray * exposureCompensationRange = [[NSArray alloc] initWithObjects: [NSNumber numberWithFloat:minExposureCompensation], [NSNumber numberWithFloat:maxExposureCompensation], nil];
+    return exposureCompensationRange;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (CGFloat)getExposureCompensation {
+
+  NSString *errMsg;
+
+  // check session is started
+
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    NSLog(@"getExposureCompensation: %zd", videoDevice.exposureTargetBias);
+    return videoDevice.exposureTargetBias;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
+  }
+}
+
+- (void)setExposureCompensation:(CGFloat)exposureCompensation {
+
+  NSString *errMsg;
+
+  // check session is started
+
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    [self.device lockForConfiguration:nil];
+    CGFloat exposureTargetBias = MAX(videoDevice.minExposureTargetBias, MIN(exposureCompensation, videoDevice.maxExposureTargetBias));
+    [videoDevice setExposureTargetBias:exposureTargetBias completionHandler:nil];
+    [self.device unlockForConfiguration];
   } else {
     errMsg = @"Session is not started";
   }

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -166,6 +166,40 @@
   });
 }
 
+- (NSArray *)getFlashModes {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+  //  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    if ([self.device hasFlash]) {
+      NSMutableArray * flashModes = [[NSMutableArray alloc] init];
+      if ([self.device isFlashModeSupported:0]) {
+        [flashModes addObject:@"off"];
+      };
+      if ([self.device isFlashModeSupported:1]) {
+        [flashModes addObject:@"on"];
+      };
+      if ([self.device isFlashModeSupported:2]) {
+        [flashModes addObject:@"auto"];
+      };
+      if ([self.device hasTorch]) {
+        [flashModes addObject:@"torch"];
+      };
+      return (NSArray *) flashModes;
+    } else {
+      errMsg = @"Flash not supported";
+    }
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
 - (void)setFlashMode:(NSInteger)flashMode {
   NSError *error = nil;
   NSString *errMsg;
@@ -322,7 +356,6 @@
 
   if (errMsg) {
     NSLog(@"%@", errMsg);
-    return 0;
   }
 }
 
@@ -357,7 +390,6 @@
   }
   if (errMsg) {
     NSLog(@"%@", errMsg);
-    return 0;
   }
 }
 

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -178,10 +178,48 @@
     if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
 
       if ([self.device lockForConfiguration:&error]) {
-
+        if ([self.device hasTorch] && [self.device isTorchAvailable]) {
+          self.device.torchMode=0;
+        }
         [self.device setFlashMode:self.defaultFlashMode];
         [self.device unlockForConfiguration];
 
+      } else {
+          NSLog(@"%@", error);
+      }
+    } else {
+      errMsg = @"Camera has no flash or flash mode not supported";
+    }
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (void)setTorchMode {
+  NSError *error = nil;
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    // Let's save the setting even if we can't set it up on this camera.
+    //self.defaultFlashMode = flashMode;
+
+    if ([self.device hasTorch] && [self.device isTorchAvailable]) {
+
+      if ([self.device lockForConfiguration:&error]) {
+
+        if ([self.device isTorchModeSupported:1]) {
+          self.device.torchMode=1;  
+        } else if ([self.device isTorchModeSupported:2]) {
+          self.device.torchMode=2;
+        } else {
+          self.device.torchMode=0;
+        }
+        [self.device unlockForConfiguration];
       } else {
           NSLog(@"%@", error);
       }
@@ -420,17 +458,19 @@
 }
 
 - (void)setExposureCompensation:(CGFloat)exposureCompensation {
-
+  NSError *error = nil;
   NSString *errMsg;
 
   // check session is started
 
   if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    [self.device lockForConfiguration:nil];
-    CGFloat exposureTargetBias = MAX(videoDevice.minExposureTargetBias, MIN(exposureCompensation, videoDevice.maxExposureTargetBias));
-    [videoDevice setExposureTargetBias:exposureTargetBias completionHandler:nil];
-    [self.device unlockForConfiguration];
+    if ([self.device lockForConfiguration:&error]) {
+      CGFloat exposureTargetBias = MAX(self.device.minExposureTargetBias, MIN(exposureCompensation, self.device.maxExposureTargetBias));
+      [self.device setExposureTargetBias:exposureTargetBias completionHandler:nil];
+      [self.device unlockForConfiguration];
+    } else {
+          NSLog(@"%@", error);
+    }  
   } else {
     errMsg = @"Session is not started";
   }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -7,7 +7,14 @@ interface CameraPreview {
   takePicture(options?:any, onSuccess?:any, onError?:any):any;
   setColorEffect(effect:string, onSuccess?:any, onError?:any):any;
   setZoom(zoom?:any, onSuccess?:any, onError?:any):any;
+  getMaxZoom(onSuccess?:any, onError?:any):any;
+  getZoom(onSuccess?:any, onError?:any):any;
   setPreviewSize(dimensions?:any, onSuccess?:any, onError?:any):any;
   getSupportedPictureSizes(onSuccess?:any, onError?:any):any;
+  getAutoExposureLock(onSuccess?:any, onError?:any):any;
+  setAutoExposureLock(lock?:any, onSuccess?:any, onError?:any):any;
+  getExposureCompensation(onSuccess?:any, onError?:any):any;
+  setExposureCompensation(exposureCompensation?:any, onSuccess?:any, onError?:any):any;
+  getExposureCompensationRange(onSuccess?:any, onError?:any):any;
   setFlashMode(flashMode:string, onSuccess?:any, onError?:any):any;
 }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -17,5 +17,6 @@ interface CameraPreview {
   getExposureCompensation(onSuccess?:any, onError?:any):any;
   setExposureCompensation(exposureCompensation?:any, onSuccess?:any, onError?:any):any;
   getExposureCompensationRange(onSuccess?:any, onError?:any):any;
+  getSupportedFlashModes(onSuccess?:any, onError?:any):any;
   setFlashMode(flashMode:string, onSuccess?:any, onError?:any):any;
 }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -11,8 +11,9 @@ interface CameraPreview {
   getZoom(onSuccess?:any, onError?:any):any;
   setPreviewSize(dimensions?:any, onSuccess?:any, onError?:any):any;
   getSupportedPictureSizes(onSuccess?:any, onError?:any):any;
-  getAutoExposureLock(onSuccess?:any, onError?:any):any;
-  setAutoExposureLock(lock?:any, onSuccess?:any, onError?:any):any;
+  getExposureModes(onSuccess?:any, onError?:any):any;
+  getExposureMode(onSuccess?:any, onError?:any):any;
+  setExposureMode(exposureMode?:any, onSuccess?:any, onError?:any):any;
   getExposureCompensation(onSuccess?:any, onError?:any):any;
   setExposureCompensation(exposureCompensation?:any, onSuccess?:any, onError?:any):any;
   getExposureCompensationRange(onSuccess?:any, onError?:any):any;

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -95,6 +95,10 @@ CameraPreview.getSupportedPictureSizes = function(onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
 };
 
+CameraPreview.getSupportedFlashModes = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFlashModes", []);
+};
+
 CameraPreview.setFlashMode = function(flashMode, onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
 };
@@ -139,7 +143,8 @@ CameraPreview.FLASH_MODE = {
     OFF: 'off',
     ON: 'on',
     AUTO: 'auto',
-    TORCH: 'torch' // Android Only
+    RED_EYE: 'red-eye', // Android Only
+    TORCH: 'torch'
 };
 
 CameraPreview.COLOR_EFFECT = {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -4,119 +4,147 @@ var argscheck = require('cordova/argscheck'),
 
 var PLUGIN_NAME = "CameraPreview";
 
-var CameraPreview = function(){};
+var CameraPreview = function() {};
 
-function isFunction(obj){
-  return !!(obj && obj.constructor && obj.call && obj.apply);
+function isFunction(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply);
 };
 
-CameraPreview.startCamera = function(options, onSuccess, onError){
-  options = options || {};
-  options.x = options.x || 0;
-  options.y = options.y || 0;
-  options.width = options.width || window.screen.width;
-  options.height = options.height || window.screen.height;
-  options.camera = options.camera || CameraPreview.CAMERA_DIRECTION.FRONT;
-  if(typeof(options.tapPhoto) === 'undefined'){
-    options.tapPhoto = true;
-  }
-  options.previewDrag = options.previewDrag || false;
-  options.toBack = options.toBack || false;
-  if(typeof(options.alpha) === 'undefined'){
-    options.alpha = 1;
-  }
+CameraPreview.startCamera = function(options, onSuccess, onError) {
+    options = options || {};
+    options.x = options.x || 0;
+    options.y = options.y || 0;
+    options.width = options.width || window.screen.width;
+    options.height = options.height || window.screen.height;
+    options.camera = options.camera || CameraPreview.CAMERA_DIRECTION.FRONT;
+    if (typeof(options.tapPhoto) === 'undefined') {
+        options.tapPhoto = true;
+    }
+    options.previewDrag = options.previewDrag || false;
+    options.toBack = options.toBack || false;
+    if (typeof(options.alpha) === 'undefined') {
+        options.alpha = 1;
+    }
 
-  exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha]);
+    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha]);
 };
 
-CameraPreview.stopCamera = function(onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "stopCamera", []);
+CameraPreview.stopCamera = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "stopCamera", []);
 };
 
-CameraPreview.switchCamera = function(onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "switchCamera", []);
+CameraPreview.switchCamera = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "switchCamera", []);
 };
 
-CameraPreview.hide = function(onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "hideCamera", []);
+CameraPreview.hide = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "hideCamera", []);
 };
 
-CameraPreview.show = function(onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "showCamera", []);
+CameraPreview.show = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "showCamera", []);
 };
 
-CameraPreview.takePicture = function(opts, onSuccess, onError){
-  if(!opts){
-    opts = {};
-  }else if(isFunction(opts)){
-    onSuccess = opts;
-    opts = {};
-  }
+CameraPreview.takePicture = function(opts, onSuccess, onError) {
+    if (!opts) {
+        opts = {};
+    } else if (isFunction(opts)) {
+        onSuccess = opts;
+        opts = {};
+    }
 
-  if(!isFunction(onSuccess)){
-    return false;
-  }
+    if (!isFunction(onSuccess)) {
+        return false;
+    }
 
-  opts.width = opts.width || 0;
-  opts.height = opts.height || 0;
+    opts.width = opts.width || 0;
+    opts.height = opts.height || 0;
 
-  if(!opts.quality || opts.quality > 100 || opts.quality < 0){
-    opts.quality = 85;
-  }
+    if (!opts.quality || opts.quality > 100 || opts.quality < 0) {
+        opts.quality = 85;
+    }
 
-  exec(onSuccess, onError, PLUGIN_NAME, "takePicture", [opts.width, opts.height, opts.quality]);
+    exec(onSuccess, onError, PLUGIN_NAME, "takePicture", [opts.width, opts.height, opts.quality]);
 };
 
-CameraPreview.setColorEffect = function(effect, onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "setColorEffect", [effect]);
+CameraPreview.setColorEffect = function(effect, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setColorEffect", [effect]);
 };
 
-CameraPreview.setZoom = function(zoom, onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "setZoom", [zoom]);
+CameraPreview.setZoom = function(zoom, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setZoom", [zoom]);
 };
 
-CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError){
-  dimensions = dimensions || {};
-  dimensions.width = dimensions.width || window.screen.width;
-  dimensions.height = dimensions.height || window.screen.height;
-
-  return exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
+CameraPreview.getMaxZoom = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getMaxZoom", []);
 };
 
-CameraPreview.getSupportedPictureSizes = function(onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
+CameraPreview.getZoom = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getZoom", []);
+};
+
+CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError) {
+    dimensions = dimensions || {};
+    dimensions.width = dimensions.width || window.screen.width;
+    dimensions.height = dimensions.height || window.screen.height;
+
+    return exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
+};
+
+CameraPreview.getSupportedPictureSizes = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
 };
 
 CameraPreview.setFlashMode = function(flashMode, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
+    exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
 };
 
-CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError){
-  exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
+CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
+};
+
+CameraPreview.getAutoExposureLock = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getAutoExposureLock", []);
+};
+
+CameraPreview.setAutoExposureLock = function(lock, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setAutoExposureLock", [lock]);
+};
+
+CameraPreview.getExposureCompensation = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensation", []);
+};
+
+CameraPreview.setExposureCompensation = function(exposureCompensation, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setExposureCompensation", [exposureCompensation]);
+};
+
+CameraPreview.getExposureCompensationRange = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", []);
 };
 
 CameraPreview.FLASH_MODE = {
-  OFF: 'off',
-  ON: 'on',
-  AUTO: 'auto',
-  TORCH: 'torch' // Android Only
+    OFF: 'off',
+    ON: 'on',
+    AUTO: 'auto',
+    TORCH: 'torch' // Android Only
 };
 
 CameraPreview.COLOR_EFFECT = {
-  AQUA: 'aqua', // Android Only
-  BLACKBOARD: 'blackboard', // Android Only
-  MONO: 'mono',
-  NEGATIVE: 'negative',
-  NONE: 'none',
-  POSTERIZE: 'posterize',
-  SEPIA: 'sepia',
-  SOLARIZE: 'solarize', // Android Only
-  WHITEBOARD: 'whiteboard' // Android Only
+    AQUA: 'aqua', // Android Only
+    BLACKBOARD: 'blackboard', // Android Only
+    MONO: 'mono',
+    NEGATIVE: 'negative',
+    NONE: 'none',
+    POSTERIZE: 'posterize',
+    SEPIA: 'sepia',
+    SOLARIZE: 'solarize', // Android Only
+    WHITEBOARD: 'whiteboard' // Android Only
 };
 
 CameraPreview.CAMERA_DIRECTION = {
-  BACK: 'back',
-  FRONT: 'front'
+    BACK: 'back',
+    FRONT: 'front'
 };
 
 module.exports = CameraPreview;

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -103,12 +103,17 @@ CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
 };
 
-CameraPreview.getAutoExposureLock = function(onSuccess, onError) {
-    exec(onSuccess, onError, PLUGIN_NAME, "getAutoExposureLock", []);
+
+CameraPreview.getExposureModes = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getExposureModes", []);
 };
 
-CameraPreview.setAutoExposureLock = function(lock, onSuccess, onError) {
-    exec(onSuccess, onError, PLUGIN_NAME, "setAutoExposureLock", [lock]);
+CameraPreview.getExposureMode = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getExposureMode", []);
+};
+
+CameraPreview.setExposureMode = function(lock, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setExposureMode", [lock]);
 };
 
 CameraPreview.getExposureCompensation = function(onSuccess, onError) {
@@ -121,6 +126,13 @@ CameraPreview.setExposureCompensation = function(exposureCompensation, onSuccess
 
 CameraPreview.getExposureCompensationRange = function(onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", []);
+};
+
+CameraPreview.EXPOSURE_MODE = {
+    LOCK: 'lock',
+    AUTO: 'auto', // IOS Only
+    CONTINUOUS: 'continuous', // IOS Only
+    CUSTOM: 'custom' // IOS Only
 };
 
 CameraPreview.FLASH_MODE = {


### PR DESCRIPTION
**New features:**
_getZoom()_ : useful to reflect the current zoom in control forms/pages.
_getMaxZoom()_: useful for range controls on forms/pages.
_getSupportedFlashModes()_: useful to disply controls on forms/pages.
_getExposureModes()_: usefull to get the suported exposure modes of the device.
_getExposureMode()_ / _setExposureMode()_: useful to get access (or not ) to exposure compensation.
_getExposureCompensation_ / _setExposureCompensation_: useful to compensate the exposure manually before taking the picture.
_getExposureCompensationRange()_ : useful for range controls on forms/pages.

**Updates:**
Additionally setFlasMode() verifies if the flash mode is supported by the device (Android).

**Note:** _This is my first experience writing code for a cordova plugin. If i made mistakes and/or things that falls outside your standards, let me know, so i can progress on the learning curve._

Kind regards,
