### PR TITLE
Doc - Wrong title for getSupportedFlashModes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ CameraPreview.takePicture(function(base64PictureData){
   /* code here */
 });
 ```
-### getSupportedPictureSizes(cb, [errorCallback])
+### getSupportedFlashModes(cb, [errorCallback])
 
 <info>Get the flash modes supported by the device. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
 


### PR DESCRIPTION
Just a little mistake (from me) in the doc for getSupportedFlashModes().
Kind Regards.
