### PR TITLE
Focus methods & getFlashMode() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ CameraPreview.takePicture(function(base64PictureData){
 ```
 ### getSupportedFocusModes(cb, [errorCallback])
 
-<info>Get focus modes supported by the camera device currently started. Returns an array containing supported focus modes. See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for posible values that can be returned.</info><br/>
+<info>Get focus modes supported by the camera device currently started. Returns an array containing supported focus modes. See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for possible values that can be returned.</info><br/>
 
 ```javascript
 CameraPreview.getSupportedFocusModes(function(focusModes){
@@ -175,7 +175,7 @@ CameraPreview.setFocusMode(CameraPreview.FOCUS_MODE.CONTINUOUS_PICTURE);
 
 ### getFocusMode(cb, [errorCallback])
 
-<info>Get the focus mode for the camera device currently started. Returns a string representing the current focus mode.</info>See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for posible values that can be returned.</info><br/>
+<info>Get the focus mode for the camera device currently started. Returns a string representing the current focus mode.</info>See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for possible values that can be returned.</info><br/>
 
 ```javascript
 CameraPreview.getFocusMode(function(currentFocusMode){
@@ -185,7 +185,7 @@ CameraPreview.getFocusMode(function(currentFocusMode){
 
 ### getSupportedFlashModes(cb, [errorCallback])
 
-<info>Get the flash modes supported by the device currently started. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
+<info>Get the flash modes supported by the camera device currently started. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for possible values that can be returned</info><br/>
 
 ```javascript
 CameraPreview.getSupportedFlashModes(function(flashModes){
@@ -207,7 +207,7 @@ CameraPreview.setFlashMode(CameraPreview.FLASH_MODE.ON);
 
 ### getFlashMode(cb, [errorCallback])
 
-<info>Get the flash mode for the device currently started. Returns a string representing the current flash mode.</info>See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
+<info>Get the flash mode for the camera device currently started. Returns a string representing the current flash mode.</info>See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for possible values that can be returned</info><br/>
 
 ```javascript
 CameraPreview.getFlashMode(function(currentFlashMode){
@@ -227,7 +227,7 @@ CameraPreview.setColorEffect(CameraPreview.COLOR_EFFECT.NEGATIVE);
 
 ### setZoom(zoomMultiplier, [successCallback, errorCallback])
 
-<info>Set the zoom level for the device currently started. zoomMultipler option accepts an integer. Zoom level is initially at 1</info><br/>
+<info>Set the zoom level for the camera device currently started. zoomMultipler option accepts an integer. Zoom level is initially at 1</info><br/>
 
 ```javascript
 CameraPreview.setZoom(2);
@@ -235,7 +235,7 @@ CameraPreview.setZoom(2);
 
 ### getZoom(cb, [errorCallback])
 
-<info>Get the current zoom level for the device currently started. Returns an integer representing the current zoom level.</info><br/>
+<info>Get the current zoom level for the camera device currently started. Returns an integer representing the current zoom level.</info><br/>
 
 ```javascript
 CameraPreview.getZoom(function(currentZoom){
@@ -245,7 +245,7 @@ CameraPreview.getZoom(function(currentZoom){
 
 ### getMaxZoom(cb, [errorCallback])
 
-<info>Get the maximum zoom level for the device currently started. Returns an integer representing the manimum zoom level.</info><br/>
+<info>Get the maximum zoom level for the camera device currently started. Returns an integer representing the manimum zoom level.</info><br/>
 
 ```javascript
 CameraPreview.getMaxZoom(function(maxZoom){
@@ -254,7 +254,7 @@ CameraPreview.getMaxZoom(function(maxZoom){
 ```
 ### getExposureModes(cb, [errorCallback])
 
-<info>Returns an array with supported exposure modes for the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
+<info>Returns an array with supported exposure modes for the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
 
 ```javascript
 CameraPreview.getExposureModes(function(exposureModes){
@@ -264,7 +264,7 @@ CameraPreview.getExposureModes(function(exposureModes){
 
 ### getExposureMode(cb, [errorCallback])
 
-<info>Get the curent exposure mode of the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
+<info>Get the curent exposure mode of the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
 
 ```javascript
 CameraPreview.getExposureMode(function(exposureMode){
@@ -273,14 +273,14 @@ CameraPreview.getExposureMode(function(exposureMode){
 ```
 ### setExposureMode(exposureMode, [successCallback, errorCallback])
 
-<info>Set the exposure modefor the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
+<info>Set the exposure modefor the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
 
 ```javascript
 CameraPreview.setExposureMode(CameraPreview.EXPOSURE_MODE.CONTINUOUS);
 ```
 ### getExposureCompensationRange(cb, [errorCallback])
 
-<info>Get the minimum and maximum exposure compensation for the device currently started. Returns an object containing min and max integers.</info><br/>
+<info>Get the minimum and maximum exposure compensation for the camera device currently started. Returns an object containing min and max integers.</info><br/>
 
 ```javascript
 CameraPreview.getExposureCompensationRange(function(expoxureRange){
@@ -290,7 +290,7 @@ CameraPreview.getExposureCompensationRange(function(expoxureRange){
 ```
 ### getExposureCompensation(cb, [errorCallback])
 
-<info>Get the current exposure compensation for the device currently started. Returns an integer representing the current exposure compensation.</info><br/>
+<info>Get the current exposure compensation for the camera device currently started. Returns an integer representing the current exposure compensation.</info><br/>
 
 ```javascript
 CameraPreview.getExposureCompensation(function(expoxureCompensation){
@@ -299,7 +299,7 @@ CameraPreview.getExposureCompensation(function(expoxureCompensation){
 ```
 ### setExposureCompensation(exposureCompensation, [successCallback, errorCallback])
 
-<info>Set the exposure compensation for the device currently started. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it is set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it is set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation).</info><br/>
+<info>Set the exposure compensation for the camera device currently started. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it is set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it is set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation).</info><br/>
 
 ```javascript
 CameraPreview.setExposureCompensation(-2);
@@ -352,7 +352,7 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | CONTINUOUS_VIDEO | string | continuous-video | Android Only |
 | EDOF | string | edof | Android Only |
 | INFINITY | string | infinity | Android Only |
-| MACRO | string | macro |  |
+| MACRO | string | macro | Android Only |
 
 <a name="camera_Settings.FlashMode"></a>
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ CameraPreview.getFocusMode(function(currentFocusMode){
 
 ```javascript
 CameraPreview.getSupportedFlashModes(function(flashModes){
-  // note that the portrait version, width and height swapped, of these dimensions are also supported
   flashModes.forEach(function(flashMode) {
     console.log(flashMode + ', ');
   });

--- a/README.md
+++ b/README.md
@@ -160,9 +160,40 @@ CameraPreview.takePicture(function(base64PictureData){
   /* code here */
 });
 ```
+### getSupportedFocusModes(cb, [errorCallback])
+
+<info>Get focus modes supported by the camera device currently started. Returns an array containing supported focus modes. See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for posible values that can be returned.</info><br/>
+
+```javascript
+CameraPreview.getSupportedFocusModes(function(focusModes){
+  focusModes.forEach(function(focusMode) {
+    console.log(focusMode + ', ');
+  });
+});
+```
+
+### setFocusMode(focusMode, [successCallback, errorCallback])
+
+<info>Set the focus mode for the camera device currently started.</info><br/>
+* `focusMode` - <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code>
+
+```javascript
+CameraPreview.setFocusMode(CameraPreview.FOCUS_MODE.CONTINUOUS_PICTURE);
+```
+
+### getFocusMode(cb, [errorCallback])
+
+<info>Get the focus mode for the camera device currently started. Returns a string representing the current focus mode.</info>See <code>[FOCUS_MODE](#camera_Settings.FocusMode)</code> for posible values that can be returned.</info><br/>
+
+```javascript
+CameraPreview.getFocusMode(function(currentFocusMode){
+  console.log(currentFocusMode);
+});
+```
+
 ### getSupportedFlashModes(cb, [errorCallback])
 
-<info>Get the flash modes supported by the device. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
+<info>Get the flash modes supported by the device currently started. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
 
 ```javascript
 CameraPreview.getSupportedFlashModes(function(flashModes){
@@ -182,6 +213,15 @@ CameraPreview.getSupportedFlashModes(function(flashModes){
 CameraPreview.setFlashMode(CameraPreview.FLASH_MODE.ON);
 ```
 
+### getFlashMode(cb, [errorCallback])
+
+<info>Get the flash mode for the device currently started. Returns a string representing the current flash mode.</info>See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for posible values that can be returned</info><br/>
+
+```javascript
+CameraPreview.getFlashMode(function(currentFlashMode){
+  console.log(currentFlashMode);
+});
+```
 ### setColorEffect(colorEffect, [successCallback, errorCallback])
 
 <info>Set the color effect.</info><br/>
@@ -195,7 +235,7 @@ CameraPreview.setColorEffect(CameraPreview.COLOR_EFFECT.NEGATIVE);
 
 ### setZoom(zoomMultiplier, [successCallback, errorCallback])
 
-<info>Set the zoom level. zoomMultipler option accepts an integer. Zoom level is initially at 1</info><br/>
+<info>Set the zoom level for the device currently started. zoomMultipler option accepts an integer. Zoom level is initially at 1</info><br/>
 
 ```javascript
 CameraPreview.setZoom(2);
@@ -203,7 +243,7 @@ CameraPreview.setZoom(2);
 
 ### getZoom(cb, [errorCallback])
 
-<info>Get the current zoom level. Returns an integer representing the current zoom level. Android only</info><br/>
+<info>Get the current zoom level for the device currently started. Returns an integer representing the current zoom level.</info><br/>
 
 ```javascript
 CameraPreview.getZoom(function(currentZoom){
@@ -213,7 +253,7 @@ CameraPreview.getZoom(function(currentZoom){
 
 ### getMaxZoom(cb, [errorCallback])
 
-<info>Get the maximum zoom level. Returns an integer representing the manimum zoom level. Android only</info><br/>
+<info>Get the maximum zoom level for the device currently started. Returns an integer representing the manimum zoom level.</info><br/>
 
 ```javascript
 CameraPreview.getMaxZoom(function(maxZoom){
@@ -222,7 +262,7 @@ CameraPreview.getMaxZoom(function(maxZoom){
 ```
 ### getExposureModes(cb, [errorCallback])
 
-<info>Returns an array with supported exposure modes. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
+<info>Returns an array with supported exposure modes for the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
 
 ```javascript
 CameraPreview.getExposureModes(function(exposureModes){
@@ -232,7 +272,7 @@ CameraPreview.getExposureModes(function(exposureModes){
 
 ### getExposureMode(cb, [errorCallback])
 
-<info>Get the curent exposure mode of the device. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
+<info>Get the curent exposure mode of the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
 
 ```javascript
 CameraPreview.getExposureMode(function(exposureMode){
@@ -241,14 +281,14 @@ CameraPreview.getExposureMode(function(exposureMode){
 ```
 ### setExposureMode(exposureMode, [successCallback, errorCallback])
 
-<info>Set the exposure mode. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
+<info>Set the exposure modefor the device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
 
 ```javascript
 CameraPreview.setExposureMode(CameraPreview.EXPOSURE_MODE.CONTINUOUS);
 ```
 ### getExposureCompensationRange(cb, [errorCallback])
 
-<info>Get the minimum and maximum exposure compensation. Returns an object containing min and max integers. Android only</info><br/>
+<info>Get the minimum and maximum exposure compensation for the device currently started. Returns an object containing min and max integers.</info><br/>
 
 ```javascript
 CameraPreview.getExposureCompensationRange(function(expoxureRange){
@@ -258,7 +298,7 @@ CameraPreview.getExposureCompensationRange(function(expoxureRange){
 ```
 ### getExposureCompensation(cb, [errorCallback])
 
-<info>Get the current exposure compensation. Returns an integer representing the current exposure compensation. Android only</info><br/>
+<info>Get the current exposure compensation for the device currently started. Returns an integer representing the current exposure compensation.</info><br/>
 
 ```javascript
 CameraPreview.getExposureCompensation(function(expoxureCompensation){
@@ -267,7 +307,7 @@ CameraPreview.getExposureCompensation(function(expoxureCompensation){
 ```
 ### setExposureCompensation(exposureCompensation, [successCallback, errorCallback])
 
-<info>Set the exposure compensation. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it is set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it is set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation). Android only</info><br/>
+<info>Set the exposure compensation for the device currently started. exposureCompensation accepts an integer. if exposureCompensation is lesser than the minimum exposure compensation, it is set to the minimum. if exposureCompensation is greater than the maximum exposure compensation, it is set to the maximum. (see getExposureCompensationRange() to get the minumum an maximum exposure compensation).</info><br/>
 
 ```javascript
 CameraPreview.setExposureCompensation(-2);
@@ -304,6 +344,23 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 ```
 
 # Settings
+
+<a name="camera_Settings.FocusMode"></a>
+
+### FOCUS_MODE
+
+<info>Focus mode settings:</info><br/>
+
+| Name | Type | Default | Note |
+| --- | --- | --- | --- |
+| FIXED | string | fixed |  |
+| AUTO | string | auto |  |
+| CONTINUOUS | string | continuous | IOS Only |
+| CONTINUOUS_PICTURE | string | continuous-picture | Android Only |
+| CONTINUOUS_VIDEO | string | continuous-video | Android Only |
+| EDOF | string | edof | Android Only |
+| INFINITY | string | infinity | Android Only |
+| MACRO | string | macro |  |
 
 <a name="camera_Settings.FlashMode"></a>
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,8 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
   <li>Set a custom alpha for the preview box.</li>
-  <li>get current zoom and maximum zoom factors</li>
-  <li>get and set exposure mode</li>
-  <li>get and set exposure compensation</li>
+  <li>Set the focus mode, zoom, color effects, exposure mode, exposure mode compensation</li>
   <li>Maintain HTML interactivity.</li>
-</ul>
-
-### Android only features
-
-<ul>
-  <li>RED_EYE flash mode do not have a corresponding API in IOS.</li>
 </ul>
 
 ### iOS only features

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -298,9 +298,11 @@ public class CameraActivity extends Fragment {
         // Check for flashMode as well to prevent error on frontward facing camera.
         List<String> supportedFlashModesNewCamera = mCamera.getParameters().getSupportedFlashModes();
         String currentFlashModePreviousCamera = cameraParameters.getFlashMode();
-        if (supportedFlashModesNewCamera != null && supportedFlashModesNewCamera.contains(currentFlashModePreviousCamera)) {
+        if (supportedFlashModesNewCamera != null && supportedFlashModesNewCamera.contains(currentFlashModePreviousCamera)) { 
           Log.d(TAG, "current flash mode supported on new camera. setting params");
-          mCamera.setParameters(cameraParameters);
+         /* mCamera.setParameters(cameraParameters);
+            The line above is disabled because parameters that can actually be changed are different from one device to another. Makes less sense trying to reconfigure them when changing camera device while those settings gan be changed using plugin methods.
+         */
         } else {
           Log.d(TAG, "current flash mode NOT supported on new camera");
         }

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -11,6 +11,9 @@
 - (void) stopCamera:(CDVInvokedUrlCommand*)command;
 - (void) showCamera:(CDVInvokedUrlCommand*)command;
 - (void) hideCamera:(CDVInvokedUrlCommand*)command;
+- (void) getFocusMode:(CDVInvokedUrlCommand*)command;
+- (void) setFocusMode:(CDVInvokedUrlCommand*)command;
+- (void) getFlashMode:(CDVInvokedUrlCommand*)command;
 - (void) setFlashMode:(CDVInvokedUrlCommand*)command;
 - (void) setZoom:(CDVInvokedUrlCommand*)command;
 - (void) getZoom:(CDVInvokedUrlCommand*)command;
@@ -27,6 +30,7 @@
 - (void) setColorEffect:(CDVInvokedUrlCommand*)command;
 - (void) getSupportedPictureSizes:(CDVInvokedUrlCommand*)command;
 - (void) getSupportedFlashModes:(CDVInvokedUrlCommand*)command;
+- (void) getSupportedFocusModes:(CDVInvokedUrlCommand*)command;
 - (void) tapToFocus:(CDVInvokedUrlCommand*)command;
 
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(int) quality;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -134,6 +134,46 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) getSupportedFocusModes:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSArray * focusModes = [self.sessionManager getFocusModes];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:focusModes];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getFocusMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSString * focusMode = [self.sessionManager getFocusMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:focusMode];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) setFocusMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  NSString * focusMode = [[command.arguments objectAtIndex:0] stringValue];
+  if (self.sessionManager != nil) {
+    [self.sessionManager setFocusMode:focusMode];
+    NSString * focusMode = [self.sessionManager getFocusMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:focusMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
+  }
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) getSupportedFlashModes:(CDVInvokedUrlCommand*)command {
   CDVPluginResult *pluginResult;
 
@@ -142,6 +182,30 @@
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:flashModes];
   } else {
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Flash not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getFlashMode:(CDVInvokedUrlCommand*)command {
+  
+  CDVPluginResult *pluginResult;
+   
+  if (self.sessionManager != nil) {
+    NSInteger flashMode = [self.sessionManager getFlashMode];
+    NSString * sFlashMode;
+    if (flashMode == 0) {
+      sFlashMode = @"off";
+    } else if (flashMode == 1) {
+      sFlashMode = @"on";
+    } else if (flashMode == 2) {
+      sFlashMode = @"auto";
+    } else {
+      sFlashMode = @"unsupported";
+    }
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:sFlashMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -5,7 +5,11 @@
 
 - (CameraSessionManager *)init;
 - (NSArray *) getDeviceFormats;
+- (NSArray *) getFocusModes;
+- (NSString *) getFocusMode;
+- (NSString *) setFocusMode:(NSString *)focusMode;
 - (NSArray *) getFlashModes;
+- (NSInteger) getFlashMode;
 - (void) setupSession:(NSString *)defaultCamera;
 - (void) switchCamera;
 - (void) setFlashMode:(NSInteger)flashMode;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -166,13 +166,115 @@
   });
 }
 
+- (NSArray *)getFocusModes {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    NSMutableArray * focusModes = [[NSMutableArray alloc] init];
+    if ([self.device isFocusModeSupported:0]) {
+      [focusModes addObject:@"fixed"];
+    };
+    if ([self.device isFocusModeSupported:1]) {
+      [focusModes addObject:@"auto"];
+    };
+    if ([self.device isFocusModeSupported:2]) {
+      [focusModes addObject:@"continuous"];
+    };
+    return (NSArray *) focusModes;
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (NSString *) getFocusMode {
+
+  NSString *errMsg;
+  NSString *focusMode;
+
+  // check session is started 
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    switch (videoDevice.focusMode) {
+      case 0:
+          focusMode = @"fixed";
+        break;
+      case 1:
+        focusMode = @"auto";
+        break;
+      case 2:
+        focusMode = @"continuous";
+        break;  
+      default:
+        focusMode = @"unsupported";
+        errMsg = @"Mode not supported";
+    }
+    return focusMode;
+  } else {
+    errMsg = @"Session is not started";
+  }
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
+- (NSString *) setFocusMode:(NSString *)focusMode {
+
+  NSString *errMsg;
+
+  // check session is started
+  if (self.session) {
+    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+    [self.device lockForConfiguration:nil];
+    if ([focusMode isEqual:@"fixed"]) {
+      if ([videoDevice isFocusModeSupported:0]) {
+        videoDevice.focusMode = 0;
+        return focusMode;
+      } else {
+        errMsg = @"Focus mode not supported";
+        return @"ERR01";
+      };
+    } else if ([focusMode isEqual:@"auto"]) {
+      if ([videoDevice isFocusModeSupported:1]) {
+        videoDevice.focusMode = 1;
+        return focusMode;
+    } else {
+        errMsg = @"Focus mode not supported";
+        return @"ERR01";
+      };
+    } else if ([focusMode isEqual:@"continuous"]) {
+      if ([videoDevice isFocusModeSupported:2]) {
+        videoDevice.focusMode = 2;
+        return focusMode;
+      } else {
+        errMsg = @"Focus mode not supported";
+        return @"ERR01";
+      };  
+    } else {
+        errMsg = @"Exposure mode not supported";
+        return @"ERR01";
+    } 
+    [self.device unlockForConfiguration];
+  } else {
+    errMsg = @"Session is not started";
+    return @"ERR02";
+  }
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+  }
+}
+
 - (NSArray *)getFlashModes {
 
   NSString *errMsg;
 
   // check session is started
   if (self.session) {
-  //  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
     if ([self.device hasFlash]) {
       NSMutableArray * flashModes = [[NSMutableArray alloc] init];
       if ([self.device isFlashModeSupported:0]) {
@@ -197,6 +299,28 @@
 
   if (errMsg) {
     NSLog(@"%@", errMsg);
+  }
+}
+
+- (NSInteger)getFlashMode {
+
+  NSString *errMsg;
+
+  // check session is started
+    
+  if (self.session) {
+    if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
+      return self.device.flashMode;
+    } else {
+      errMsg = @"Flash not supported";
+    }
+  } else {
+    errMsg = @"Session is not started";
+  }
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return 0;
   }
 }
 

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -6,6 +6,9 @@ interface CameraPreview {
   show(onSuccess?:any, onError?:any):any;
   takePicture(options?:any, onSuccess?:any, onError?:any):any;
   setColorEffect(effect:string, onSuccess?:any, onError?:any):any;
+  getSupportedFocusMode(onSuccess?:any, onError?:any):any;
+  getFocusMode(onSuccess?:any, onError?:any):any;
+  setFocusMode(onSuccess?:any, onError?:any):any;
   setZoom(zoom?:any, onSuccess?:any, onError?:any):any;
   getMaxZoom(onSuccess?:any, onError?:any):any;
   getZoom(onSuccess?:any, onError?:any):any;

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -103,6 +103,22 @@ CameraPreview.setFlashMode = function(flashMode, onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
 };
 
+CameraPreview.getFlashMode = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getFlashMode", []);
+};
+
+CameraPreview.getSupportedFocusModes = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFocusModes", []);
+};
+
+CameraPreview.getFocusMode = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getFocusMode", []);
+};
+
+CameraPreview.setFocusMode = function(focusMode, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setFocusMode", [focusMode]);
+};
+
 CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
 };
@@ -130,6 +146,17 @@ CameraPreview.setExposureCompensation = function(exposureCompensation, onSuccess
 
 CameraPreview.getExposureCompensationRange = function(onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", []);
+};
+
+CameraPreview.FOCUS_MODE = {
+    FIXED: 'fixed',
+    AUTO: 'auto',
+    CONTINUOUS: 'continuous', // IOS Only
+    CONTINUOUS_PICTURE: 'continuous-picture', // Android Only
+    CONTINUOUS_VIDEO: 'continuous-video', // Android Only
+    EDOF: 'edof', // Android Only
+    INFINITY: 'infinity', // Android Only
+    MACRO: 'macro' // Android Only
 };
 
 CameraPreview.EXPOSURE_MODE = {


### PR DESCRIPTION
Hi, 
I propose the following new methods for managing the focus of the camera device currently started:
- getSupportedFocusModes()
- getFocusMode();
- setFocusMode();

and the missing method for the flash:
- getFlashMode();

Kind regards