### PR TITLE
New white balance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Cordova plugin that allows camera interaction from HTML code for showing camera 
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
   <li>Set a custom alpha for the preview box.</li>
-  <li>Set the focus mode, zoom, color effects, exposure mode, white balance and exposure compensation</li>
+  <li>Set the focus mode, zoom, color effects, exposure mode, white balance mode and exposure compensation</li>
   <li>Maintain HTML interactivity.</li>
 </ul>
 
@@ -252,7 +252,7 @@ CameraPreview.getMaxZoom(function(maxZoom){
 });
 ```
 
-### getSuppoertedWhiteBalanceModes(cb, [errorCallback])
+### getSupportedWhiteBalanceModes(cb, [errorCallback])
 
 <info>Returns an array with supported white balance modes for the camera device currently started. See <code>[WHITE_BALANCE_MODE](#camera_Settings.WhiteBalanceMode)</code> for details about the possible values returned.</info><br/>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Cordova Plugin Camera Preview
 ====================
 
-Cordova plugin that allows camera interaction from HTML ee for showing camera preview below or above the HTML.<br/>
+Cordova plugin that allows camera interaction from HTML code for showing camera preview below or above the HTML.<br/>
 
 **March 4, 2017** - We are currently drastically improving the plugin for a v1.0.0 release, in the meantime the API may change slightly. Please use master until a new version is released.
 
@@ -17,7 +17,7 @@ Cordova plugin that allows camera interaction from HTML ee for showing camera pr
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
   <li>Set a custom alpha for the preview box.</li>
-  <li>Set the focus mode, zoom, color effects, exposure mode, exposure mode compensation</li>
+  <li>Set the focus mode, zoom, color effects, exposure mode, white balance and exposure compensation</li>
   <li>Maintain HTML interactivity.</li>
 </ul>
 
@@ -197,7 +197,8 @@ CameraPreview.getSupportedFlashModes(function(flashModes){
 
 ### setFlashMode(flashMode, [successCallback, errorCallback])
 
-<info>Set the flash mode. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for details about the possible values for flashMode.</info><br/>
+<info>Set the flash mode.</info><br/>
+* `flashMode` - <code>[FLASH_MODE](#camera_Settings.FlashMode)</code>
 
 ```javascript
 CameraPreview.setFlashMode(CameraPreview.FLASH_MODE.ON);
@@ -214,7 +215,10 @@ CameraPreview.getFlashMode(function(currentFlashMode){
 ```
 ### setColorEffect(colorEffect, [successCallback, errorCallback])
 
-<info>Set the color effect. See <code>[COLOR_EFFECT](#camera_Settings.ColorEffect)</code> for details about the possible values for colorEffect.</info><br/>
+<info>Set the color effect.</info><br/>
+
+* `colorEffect` - <code>[COLOR_EFFECT](#camera_Settings.ColorEffect)</code>
+
 
 ```javascript
 CameraPreview.setColorEffect(CameraPreview.COLOR_EFFECT.NEGATIVE);
@@ -247,6 +251,34 @@ CameraPreview.getMaxZoom(function(maxZoom){
   console.log(maxZoom);
 });
 ```
+
+### getSuppoertedWhiteBalanceModes(cb, [errorCallback])
+
+<info>Returns an array with supported white balance modes for the camera device currently started. See <code>[WHITE_BALANCE_MODE](#camera_Settings.WhiteBalanceMode)</code> for details about the possible values returned.</info><br/>
+
+```javascript
+CameraPreview.getSupportedWhiteBalanceModes(function(whiteBalanceModes){
+  console.log(whiteBalanceModes);
+});
+```
+
+### getWhiteBalanceMode(cb, [errorCallback])
+
+<info>Get the curent white balance mode of the camera device currently started. See <code>[WHITE_BALANCE_MODE](#camera_Settings.WhiteBalanceMode)</code> for details about the possible values returned.</info><br/>
+
+```javascript
+CameraPreview.getWhiteBalanceMode(function(whiteBalanceMode){
+  console.log(whiteBalanceMode);
+});
+```
+### setWhiteBalanceMode(whiteBalanceMode, [successCallback, errorCallback])
+
+<info>Set the white balance mode for the camera device currently started. See <code>[WHITE_BALANCE_MODE](#camera_Settings.WhiteBalanceMode)</code> for details about the possible values for whiteBalanceMode.</info><br/>
+
+```javascript
+CameraPreview.setWhiteBalanceMode(CameraPreview.WHITE_BALANCE_MODE.CLOUDY_DAYLIGHT);
+```
+
 ### getExposureModes(cb, [errorCallback])
 
 <info>Returns an array with supported exposure modes for the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values returned.</info><br/>
@@ -268,7 +300,7 @@ CameraPreview.getExposureMode(function(exposureMode){
 ```
 ### setExposureMode(exposureMode, [successCallback, errorCallback])
 
-<info>Set the exposure modefor the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
+<info>Set the exposure mode for the camera device currently started. See <code>[EXPOSURE_MODE](#camera_Settings.ExposureMode)</code> for details about the possible values for exposureMode.</info><br/>
 
 ```javascript
 CameraPreview.setExposureMode(CameraPreview.EXPOSURE_MODE.CONTINUOUS);
@@ -406,6 +438,25 @@ CameraPreview.tapToFocus(xPoint, yPoint);
 | LOCK | string | lock | IOS Only |
 
 Note: Use AUTO to allow the device automatically adjusts the exposure once and then changes the exposure mode to LOCK.
+
+<a name="camera_Settings.WhiteBalanceMode"></a>
+
+### WHITE_BALANCE_MODE
+
+<info>White balance mode settings:</info><br/>
+
+| Name | Type | Default | Note |
+| --- | --- | --- | --- |
+| LOCK | string | lock | |
+| AUTO | string | auto | |
+| CONTINUOUS | string | continuous | IOS Only |
+| INCANDESCENT | string | incandescent | |
+| CLOUDY_DAYLIGHT | string | cloudy-daylight | |
+| DAYLIGHT | string | daylight | |
+| FLUORESCENT | string | fluorescent | |
+| SHADE | string | shade | |
+| TWILIGHT | string | twilight | |
+| WARM_FLUORESCENT | string | warm-fluorescent | |
 
 # IOS Quirks
 It is not possible to use your computers webcam during testing in the simulator, you must device test.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Cordova Plugin Camera Preview
 ====================
 
-Cordova plugin that allows camera interaction from HTML code for showing camera preview below or above the HTML.<br/>
-
 **March 4, 2017** - We are currently drastically improving the plugin for a v1.0.0 release, in the meantime the API may change slightly. Please use master until a new version is released.
 
 **PR's are greatly appreciated. If your interested in maintainer status please create a couple PR's and then contact westonganger@gmail.com**
@@ -197,8 +195,7 @@ CameraPreview.getSupportedFlashModes(function(flashModes){
 
 ### setFlashMode(flashMode, [successCallback, errorCallback])
 
-<info>Set the flash mode.</info><br/>
-* `flashMode` - <code>[FLASH_MODE](#camera_Settings.FlashMode)</code>
+<info>Set the flash mode. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for details about the possible values for flashMode.</info><br/>
 
 ```javascript
 CameraPreview.setFlashMode(CameraPreview.FLASH_MODE.ON);
@@ -215,10 +212,7 @@ CameraPreview.getFlashMode(function(currentFlashMode){
 ```
 ### setColorEffect(colorEffect, [successCallback, errorCallback])
 
-<info>Set the color effect.</info><br/>
-
-* `colorEffect` - <code>[COLOR_EFFECT](#camera_Settings.ColorEffect)</code>
-
+<info>Set the color effect. See <code>[COLOR_EFFECT](#camera_Settings.ColorEffect)</code> for details about the possible values for colorEffect.</info><br/>
 
 ```javascript
 CameraPreview.setColorEffect(CameraPreview.COLOR_EFFECT.NEGATIVE);

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin id="cordova-plugin-camera-preview" version="0.9.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <name>cordova-plugin-camera-preview</name>
+   <name>cordova-plugin-camera-preview</name>
   <description>Cordova plugin that allows camera interaction from HTML code. Show camera preview popup on top of the HTML.</description>
   <license>Apache 2.0</license>
   <keywords>cordova,phonegap,ecosystem:cordova,cordova-android,cordova-ios,android,ios,ionic,camera,cam,camera-preview,preview</keywords>
@@ -50,6 +50,9 @@
 
     <header-file src="src/ios/CameraPreview.h" />
     <source-file src="src/ios/CameraPreview.m" />
+
+     <header-file src="src/ios/TemperatureAndTint.h" />
+    <source-file src="src/ios/TemperatureAndTint.m" />
 
     <header-file src="src/ios/CameraSessionManager.h" />
     <source-file src="src/ios/CameraSessionManager.m" />

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -32,6 +32,10 @@
 - (void) getSupportedFlashModes:(CDVInvokedUrlCommand*)command;
 - (void) getSupportedFocusModes:(CDVInvokedUrlCommand*)command;
 - (void) tapToFocus:(CDVInvokedUrlCommand*)command;
+- (void) getSupportedWhiteBalanceModes:(CDVInvokedUrlCommand*)command;
+- (void) getWhiteBalanceMode:(CDVInvokedUrlCommand*)command;
+- (void) setWhiteBalanceMode:(CDVInvokedUrlCommand*)command;
+
 
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(int) quality;
 - (void) invokeTakePicture;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -315,13 +315,53 @@
 - (void) setExposureMode:(CDVInvokedUrlCommand*)command {
   CDVPluginResult *pluginResult;
 
-  NSString * exposureMode = [[command.arguments objectAtIndex:0] stringValue];
+  NSString * exposureMode = [command.arguments objectAtIndex:0];
   if (self.sessionManager != nil) {
     [self.sessionManager setExposureMode:exposureMode];
     NSString * exposureMode = [self.sessionManager getExposureMode];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:exposureMode ];
   } else {
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+  }
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getSupportedWhiteBalanceModes:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSArray * whiteBalanceModes = [self.sessionManager getSupportedWhiteBalanceModes];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:whiteBalanceModes ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) getWhiteBalanceMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  if (self.sessionManager != nil) {
+    NSString * whiteBalanceMode = [self.sessionManager getWhiteBalanceMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:whiteBalanceMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) setWhiteBalanceMode:(CDVInvokedUrlCommand*)command {
+  CDVPluginResult *pluginResult;
+
+  NSString * whiteBalanceMode = [command.arguments objectAtIndex:0];
+  if (self.sessionManager != nil) {
+    [self.sessionManager setWhiteBalanceMode:whiteBalanceMode];
+    NSString * wbMode = [self.sessionManager getWhiteBalanceMode];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:wbMode ];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
   }
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -1,5 +1,6 @@
 #import <CoreImage/CoreImage.h>
 #import <AVFoundation/AVFoundation.h>
+#import "TemperatureAndTint.h"
 
 @interface CameraSessionManager : NSObject
 
@@ -22,6 +23,9 @@
 - (NSArray *) getExposureCompensationRange;
 - (CGFloat) getExposureCompensation;
 - (void) setExposureCompensation:(CGFloat)exposureCompensation;
+- (NSArray *) getSupportedWhiteBalanceModes;
+- (NSString *) getWhiteBalanceMode;
+- (NSString *) setWhiteBalanceMode:(NSString *)whiteBalanceMode;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
 - (void) setTorchMode;
@@ -39,5 +43,7 @@
 @property (nonatomic) AVCaptureStillImageOutput *stillImageOutput;
 @property (nonatomic) AVCaptureVideoDataOutput *dataOutput;
 @property (nonatomic, assign) id delegate;
+@property (nonatomic) NSString *currentWhiteBalanceMode;
+@property (nonatomic) NSDictionary *colorTemperatures;
 
 @end

--- a/src/ios/TemperatureAndTint.h
+++ b/src/ios/TemperatureAndTint.h
@@ -1,0 +1,10 @@
+#import <AVFoundation/AVFoundation.h>
+
+@interface TemperatureAndTint: NSObject
+
+@property (nonatomic) NSString* mode;
+@property (nonatomic) float minTemperature;
+@property (nonatomic) float maxTemperature;
+@property (nonatomic) float tint;
+
+@end

--- a/src/ios/TemperatureAndTint.m
+++ b/src/ios/TemperatureAndTint.m
@@ -1,0 +1,9 @@
+#include "TemperatureAndTint.h"
+
+@implementation TemperatureAndTint
+@synthesize mode;
+@synthesize minTemperature;
+@synthesize maxTemperature;
+@synthesize tint;
+
+@end

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -22,4 +22,7 @@ interface CameraPreview {
   getExposureCompensationRange(onSuccess?:any, onError?:any):any;
   getSupportedFlashModes(onSuccess?:any, onError?:any):any;
   setFlashMode(flashMode:string, onSuccess?:any, onError?:any):any;
+  getSupportedWhiteBalanceModes(onSuccess?:any, onError?:any):any;
+  getSupportedWhiteBalanceMode(onSuccess?:any, onError?:any):any;
+  setWhiteBalanceMode(whiteBalanceMode?:any, onSuccess?:any, onError?:any):any;
 }

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -132,8 +132,8 @@ CameraPreview.getExposureMode = function(onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "getExposureMode", []);
 };
 
-CameraPreview.setExposureMode = function(lock, onSuccess, onError) {
-    exec(onSuccess, onError, PLUGIN_NAME, "setExposureMode", [lock]);
+CameraPreview.setExposureMode = function(exposureMode, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setExposureMode", [exposureMode]);
 };
 
 CameraPreview.getExposureCompensation = function(onSuccess, onError) {
@@ -146,6 +146,18 @@ CameraPreview.setExposureCompensation = function(exposureCompensation, onSuccess
 
 CameraPreview.getExposureCompensationRange = function(onSuccess, onError) {
     exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", []);
+};
+
+CameraPreview.getSupportedWhiteBalanceModes = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getSupportedWhiteBalanceModes", []);
+};
+
+CameraPreview.getWhiteBalanceMode = function(onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "getWhiteBalanceMode", []);
+};
+
+CameraPreview.setWhiteBalanceMode = function(whiteBalanceMode, onSuccess, onError) {
+    exec(onSuccess, onError, PLUGIN_NAME, "setWhiteBalanceMode", [whiteBalanceMode]);
 };
 
 CameraPreview.FOCUS_MODE = {
@@ -164,6 +176,19 @@ CameraPreview.EXPOSURE_MODE = {
     AUTO: 'auto', // IOS Only
     CONTINUOUS: 'continuous', // IOS Only
     CUSTOM: 'custom' // IOS Only
+};
+
+CameraPreview.WHITE_BALANCE_MODE = {
+    LOCK: 'lock',
+    AUTO: 'auto',
+    CONTINUOUS: 'continuous', // IOS Only
+    INCANDESCENT: 'incandescent', // Android Only
+    CLOUDY_DAYLIGHT: 'cloudy-daylight', // Android Only
+    DAYLIGHT: 'daylight', // Android Only
+    FLUORESCENT: 'fluorescent', // Android Only
+    SHADE: 'shade', // Android Only
+    TWILIGHT: 'twilight', // Android Only
+    WARM_FLUORESCENT: 'warm-fluorescent' // Android Only
 };
 
 CameraPreview.FLASH_MODE = {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -181,14 +181,14 @@ CameraPreview.EXPOSURE_MODE = {
 CameraPreview.WHITE_BALANCE_MODE = {
     LOCK: 'lock',
     AUTO: 'auto',
-    CONTINUOUS: 'continuous', // IOS Only
-    INCANDESCENT: 'incandescent', // Android Only
-    CLOUDY_DAYLIGHT: 'cloudy-daylight', // Android Only
-    DAYLIGHT: 'daylight', // Android Only
-    FLUORESCENT: 'fluorescent', // Android Only
-    SHADE: 'shade', // Android Only
-    TWILIGHT: 'twilight', // Android Only
-    WARM_FLUORESCENT: 'warm-fluorescent' // Android Only
+    CONTINUOUS: 'continuous',
+    INCANDESCENT: 'incandescent',
+    CLOUDY_DAYLIGHT: 'cloudy-daylight',
+    DAYLIGHT: 'daylight',
+    FLUORESCENT: 'fluorescent',
+    SHADE: 'shade',
+    TWILIGHT: 'twilight',
+    WARM_FLUORESCENT: 'warm-fluorescent'
 };
 
 CameraPreview.FLASH_MODE = {


### PR DESCRIPTION
Hi, i propose 3 new methods to get basic white balance modes:
- getSuportedWhiteBalanceModes()
- getWhiteBalanceMode()
- setWhiteBalanceMode()

Note: IOS API do not support white balance predefined modes (INCANDESCENT, CLOUDY_DAYLIGHT, DAYLIGHT,  FLUORESCENT, SHADE, TWILIGHT, WARM_FLUORESCENT) like Android API does.
I designed a class for typical values corresponding to the color temperature (in KELVIN) and tint (tint is set to zero for white light), to be able to set the corresponding white balance gains converted in RGB gains understandable by IOS API.
The getSupportedWhiteBalanceModes() and setWhiteBalanceMode() method implementation for IOS take care of the device's maximum gain for each red, green, blue gain. 
I compare the results with Android devices using OpenCamera. I also compare the color temparatures with VSCO app on IOS.

Note that it seems that manual adjustment of the white balance using RGB gains in Android seems to be possible if using the camera2 Android API (since API level 21), This manual setting could be implemented for both Android and IOS in a further stage of the pluging when supporting the camer2 API.

Edit: I also includes minor corrections for bugs in exposure methods.

Kind Regards