### PR TITLE
fix several iOS bugs

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -128,7 +128,7 @@
     [self.sessionManager switchCamera];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -181,16 +181,16 @@
     NSArray * flashModes = [self.sessionManager getFlashModes];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:flashModes];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Flash not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) getFlashMode:(CDVInvokedUrlCommand*)command {
-  
+
   CDVPluginResult *pluginResult;
-   
+
   if (self.sessionManager != nil) {
     NSInteger flashMode = [self.sessionManager getFlashMode];
     NSString * sFlashMode;
@@ -205,7 +205,7 @@
     }
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:sFlashMode ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -223,15 +223,15 @@
       [self.sessionManager setFlashMode:AVCaptureFlashModeOff];
     } else if ([flashMode isEqual: @"on"]) {
       [self.sessionManager setFlashMode:AVCaptureFlashModeOn];
-    } else if ([flashMode isEqual: @"auto"]) {  
+    } else if ([flashMode isEqual: @"auto"]) {
       [self.sessionManager setFlashMode:AVCaptureFlashModeAuto];
     } else if ([flashMode isEqual: @"torch"]) {
-      [self.sessionManager setTorchMode];  
+      [self.sessionManager setTorchMode];
     } else {
       errMsg = @"Flash Mode not supported";
     }
   } else {
-    errMsg = @"Camera not started";
+    errMsg = @"Session not started";
   }
 
   if (errMsg) {
@@ -253,21 +253,21 @@
     [self.sessionManager setZoom:desiredZoomFactor];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not not zoomed"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) getZoom:(CDVInvokedUrlCommand*)command {
-  
+
   CDVPluginResult *pluginResult;
 
   if (self.sessionManager != nil) {
     CGFloat zoom = [self.sessionManager getZoom];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:zoom ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not zoomed"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -280,7 +280,7 @@
     CGFloat maxZoom = [self.sessionManager getMaxZoom];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:maxZoom ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not zoomed"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -293,7 +293,7 @@
     NSArray * exposureModes = [self.sessionManager getExposureModes];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:exposureModes];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -306,7 +306,7 @@
     NSString * exposureMode = [self.sessionManager getExposureMode];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:exposureMode ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -321,7 +321,7 @@
     NSString * exposureMode = [self.sessionManager getExposureMode];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:exposureMode ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Exposure modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -333,7 +333,7 @@
     NSArray * whiteBalanceModes = [self.sessionManager getSupportedWhiteBalanceModes];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:whiteBalanceModes ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -346,7 +346,7 @@
     NSString * whiteBalanceMode = [self.sessionManager getWhiteBalanceMode];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:whiteBalanceMode ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -361,7 +361,7 @@
     NSString * wbMode = [self.sessionManager getWhiteBalanceMode];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:wbMode ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"White balance modes not supported"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -376,7 +376,7 @@
     [dimensions setValue:exposureRange[1] forKey:@"max"];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dimensions];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No session started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -388,7 +388,7 @@
     CGFloat exposureCompensation = [self.sessionManager getExposureCompensation];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:exposureCompensation ];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -404,7 +404,7 @@
     [self.sessionManager setExposureCompensation:exposureCompensation];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:exposureCompensation];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -466,7 +466,7 @@
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Filter not found"];
     }
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -477,7 +477,7 @@
     CDVPluginResult *pluginResult;
 
     if (self.sessionManager == nil) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera did not start!"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
@@ -521,7 +521,7 @@
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:jsonFormats];
 
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -553,7 +553,7 @@
     [self.sessionManager tapToFocus:xPoint yPoint:yPoint];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not tapped to focus"];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
   }
 
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -61,14 +61,17 @@
 
     // Setup session
     self.sessionManager.delegate = self.cameraRenderController;
-    [self.sessionManager setupSession:defaultCamera];
 
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.sessionManager setupSession:defaultCamera completion:^(BOOL started) {
+
+      [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+
+    }];
+
   } else {
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid number of parameters"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }
-
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) stopCamera:(CDVInvokedUrlCommand*)command {
@@ -125,13 +128,17 @@
   CDVPluginResult *pluginResult;
 
   if (self.sessionManager != nil) {
-    [self.sessionManager switchCamera];
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-  } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
-  }
+    [self.sessionManager switchCamera:^(BOOL switched) {
 
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+
+    }];
+
+  } else {
+
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+  }
 }
 
 - (void) getSupportedFocusModes:(CDVInvokedUrlCommand*)command {

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -11,8 +11,8 @@
 - (NSString *) setFocusMode:(NSString *)focusMode;
 - (NSArray *) getFlashModes;
 - (NSInteger) getFlashMode;
-- (void) setupSession:(NSString *)defaultCamera;
-- (void) switchCamera;
+- (void) setupSession:(NSString *)defaultCamera completion:(void(^)(BOOL started))completion;
+- (void) switchCamera:(void(^)(BOOL switched))completion;
 - (void) setFlashMode:(NSInteger)flashMode;
 - (void) setZoom:(CGFloat)desiredZoomFactor;
 - (CGFloat) getZoom;

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -89,12 +89,13 @@
   return orientation;
 }
 
-- (void) setupSession:(NSString *)defaultCamera {
+- (void) setupSession:(NSString *)defaultCamera completion:(void(^)(BOOL started))completion{
   // If this fails, video input will just stream blank frames and the user will be notified. User only has to accept once.
   [self checkDeviceAuthorizationStatus];
 
   dispatch_async(self.sessionQueue, ^{
       NSError *error = nil;
+      BOOL success = TRUE;
 
       NSLog(@"defaultCamera: %@", defaultCamera);
       if ([defaultCamera isEqual: @"front"]) {
@@ -111,6 +112,7 @@
           [videoDevice unlockForConfiguration];
         } else {
           NSLog(@"%@", error);
+          success = FALSE;
         }
       }
 
@@ -118,6 +120,7 @@
 
       if (error) {
         NSLog(@"%@", error);
+        success = FALSE;
       }
 
       if ([self.session canAddInput:videoDeviceInput]) {
@@ -145,6 +148,8 @@
 
       [self updateOrientation:[self getCurrentOrientation]];
       self.device = videoDevice;
+
+      completion(success);
   });
 }
 
@@ -164,7 +169,7 @@
   }
 }
 
-- (void) switchCamera {
+- (void) switchCamera:(void(^)(BOOL switched))completion {
   if (self.defaultCamera == AVCaptureDevicePositionFront) {
     self.defaultCamera = AVCaptureDevicePositionBack;
   } else {
@@ -173,6 +178,7 @@
 
   dispatch_async([self sessionQueue], ^{
       NSError *error = nil;
+      BOOL success = TRUE;
 
       [self.session beginConfiguration];
 
@@ -191,6 +197,7 @@
           [videoDevice unlockForConfiguration];
         } else {
           NSLog(@"%@", error);
+          success = FALSE;
         }
       }
 
@@ -198,6 +205,7 @@
 
       if (error) {
         NSLog(@"%@", error);
+        success = FALSE;
       }
 
       if ([self.session canAddInput:videoDeviceInput]) {
@@ -208,6 +216,8 @@
       [self updateOrientation:[self getCurrentOrientation]];
       [self.session commitConfiguration];
       self.device = videoDevice;
+
+      completion(success);
   });
 }
 

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -11,7 +11,7 @@
       [self.session setSessionPreset:AVCaptureSessionPresetPhoto];
     }
     self.filterLock = [[NSLock alloc] init];
-    
+
     TemperatureAndTint * wbIncandescent = [[TemperatureAndTint alloc] init];
     wbIncandescent.mode = @"incandescent";
     wbIncandescent.minTemperature = 2200;
@@ -23,7 +23,7 @@
     wbCloudyDaylight.minTemperature = 6000;
     wbCloudyDaylight.maxTemperature = 7000;
     wbCloudyDaylight.tint = 0;
-    
+
     TemperatureAndTint * wbDaylight = [[TemperatureAndTint alloc] init];
     wbDaylight.mode = @"daylight";
     wbDaylight.minTemperature = 5500;
@@ -55,7 +55,7 @@
     wbTwilight.tint = 0;
 
     self.colorTemperatures = [NSDictionary dictionaryWithObjects:@[wbIncandescent,wbCloudyDaylight,wbDaylight,wbFluorescent,wbShade,wbWarmFluorescent,wbTwilight]
-                                           forKeys:@[@"incandescent",@"cloudy-daylight",@"daylight",@"fluorescent",@"shade",@"warm-fluorescent",@"twilight"]];   
+                                           forKeys:@[@"incandescent",@"cloudy-daylight",@"daylight",@"fluorescent",@"shade",@"warm-fluorescent",@"twilight"]];
   }
   return self;
 }
@@ -213,404 +213,274 @@
 
 - (NSArray *)getFocusModes {
 
-  NSString *errMsg;
+  NSMutableArray * focusModes = [[NSMutableArray alloc] init];
 
-  // check session is started
-  if (self.session) {
-    NSMutableArray * focusModes = [[NSMutableArray alloc] init];
-    if ([self.device isFocusModeSupported:0]) {
-      [focusModes addObject:@"fixed"];
-    };
-    if ([self.device isFocusModeSupported:1]) {
-      [focusModes addObject:@"auto"];
-    };
-    if ([self.device isFocusModeSupported:2]) {
-      [focusModes addObject:@"continuous"];
-    };
-    return (NSArray *) focusModes;
-  } else {
-    errMsg = @"Session is not started";
-  }
+  if ([self.device isFocusModeSupported:0]) {
+    [focusModes addObject:@"fixed"];
+  };
+  if ([self.device isFocusModeSupported:1]) {
+    [focusModes addObject:@"auto"];
+  };
+  if ([self.device isFocusModeSupported:2]) {
+    [focusModes addObject:@"continuous"];
+  };
 
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  return (NSArray *) focusModes;
 }
 
 - (NSString *) getFocusMode {
 
-  NSString *errMsg;
   NSString *focusMode;
 
-  // check session is started 
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    switch (videoDevice.focusMode) {
-      case 0:
-          focusMode = @"fixed";
-        break;
-      case 1:
-        focusMode = @"auto";
-        break;
-      case 2:
-        focusMode = @"continuous";
-        break;  
-      default:
-        focusMode = @"unsupported";
-        errMsg = @"Mode not supported";
-    }
-    return focusMode;
-  } else {
-    errMsg = @"Session is not started";
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  switch (videoDevice.focusMode) {
+    case 0:
+        focusMode = @"fixed";
+      break;
+    case 1:
+      focusMode = @"auto";
+      break;
+    case 2:
+      focusMode = @"continuous";
+      break;
+    default:
+      focusMode = @"unsupported";
+      NSLog(@"Mode not supported");
   }
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+
+  return focusMode;
 }
 
 - (NSString *) setFocusMode:(NSString *)focusMode {
 
   NSString *errMsg;
 
-  // check session is started
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    [self.device lockForConfiguration:nil];
-    if ([focusMode isEqual:@"fixed"]) {
-      if ([videoDevice isFocusModeSupported:0]) {
-        videoDevice.focusMode = 0;
-        return focusMode;
-      } else {
-        errMsg = @"Focus mode not supported";
-        return @"ERR01";
-      };
-    } else if ([focusMode isEqual:@"auto"]) {
-      if ([videoDevice isFocusModeSupported:1]) {
-        videoDevice.focusMode = 1;
-        return focusMode;
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  [self.device lockForConfiguration:nil];
+
+  if ([focusMode isEqual:@"fixed"]) {
+    if ([videoDevice isFocusModeSupported:0]) {
+      videoDevice.focusMode = 0;
+      return focusMode;
     } else {
-        errMsg = @"Focus mode not supported";
-        return @"ERR01";
-      };
-    } else if ([focusMode isEqual:@"continuous"]) {
-      if ([videoDevice isFocusModeSupported:2]) {
-        videoDevice.focusMode = 2;
-        return focusMode;
-      } else {
-        errMsg = @"Focus mode not supported";
-        return @"ERR01";
-      };  
-    } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-    } 
-    [self.device unlockForConfiguration];
+      errMsg = @"Focus mode not supported";
+      return @"ERR01";
+    };
+  } else if ([focusMode isEqual:@"auto"]) {
+    if ([videoDevice isFocusModeSupported:1]) {
+      videoDevice.focusMode = 1;
+      return focusMode;
   } else {
-    errMsg = @"Session is not started";
-    return @"ERR02";
+      errMsg = @"Focus mode not supported";
+      return @"ERR01";
+    };
+  } else if ([focusMode isEqual:@"continuous"]) {
+    if ([videoDevice isFocusModeSupported:2]) {
+      videoDevice.focusMode = 2;
+      return focusMode;
+    } else {
+      errMsg = @"Focus mode not supported";
+      return @"ERR01";
+    };
+  } else {
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
   }
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+
+  [self.device unlockForConfiguration];
 }
 
 - (NSArray *)getFlashModes {
+  NSMutableArray * flashModes = [[NSMutableArray alloc] init];
 
-  NSString *errMsg;
-
-  // check session is started
-  if (self.session) {
-    if ([self.device hasFlash]) {
-      NSMutableArray * flashModes = [[NSMutableArray alloc] init];
-      if ([self.device isFlashModeSupported:0]) {
-        [flashModes addObject:@"off"];
-      };
-      if ([self.device isFlashModeSupported:1]) {
-        [flashModes addObject:@"on"];
-      };
-      if ([self.device isFlashModeSupported:2]) {
-        [flashModes addObject:@"auto"];
-      };
-      if ([self.device hasTorch]) {
-        [flashModes addObject:@"torch"];
-      };
-      return (NSArray *) flashModes;
-    } else {
-      errMsg = @"Flash not supported";
-    }
-  } else {
-    errMsg = @"Session is not started";
+  if ([self.device hasFlash]) {
+    if ([self.device isFlashModeSupported:0]) {
+      [flashModes addObject:@"off"];
+    };
+    if ([self.device isFlashModeSupported:1]) {
+      [flashModes addObject:@"on"];
+    };
+    if ([self.device isFlashModeSupported:2]) {
+      [flashModes addObject:@"auto"];
+    };
+    if ([self.device hasTorch]) {
+      [flashModes addObject:@"torch"];
+    };
   }
 
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  return (NSArray *) flashModes;
 }
 
 - (NSInteger)getFlashMode {
 
-  NSString *errMsg;
-
-  // check session is started
-    
-  if (self.session) {
-    if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
-      return self.device.flashMode;
-    } else {
-      errMsg = @"Flash not supported";
-    }
-  } else {
-    errMsg = @"Session is not started";
+  if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
+    return self.device.flashMode;
   }
 
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-    return 0;
-  }
+  return -1;
 }
 
 - (void)setFlashMode:(NSInteger)flashMode {
   NSError *error = nil;
-  NSString *errMsg;
 
-  // check session is started
-  if (self.session) {
-    // Let's save the setting even if we can't set it up on this camera.
-    self.defaultFlashMode = flashMode;
+  // Let's save the setting even if we can't set it up on this camera.
+  self.defaultFlashMode = flashMode;
 
-    if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
+  if ([self.device hasFlash] && [self.device isFlashModeSupported:self.defaultFlashMode]) {
 
-      if ([self.device lockForConfiguration:&error]) {
-        if ([self.device hasTorch] && [self.device isTorchAvailable]) {
-          self.device.torchMode=0;
-        }
-        [self.device setFlashMode:self.defaultFlashMode];
-        [self.device unlockForConfiguration];
-
-      } else {
-          NSLog(@"%@", error);
+    if ([self.device lockForConfiguration:&error]) {
+      if ([self.device hasTorch] && [self.device isTorchAvailable]) {
+        self.device.torchMode=0;
       }
+      [self.device setFlashMode:self.defaultFlashMode];
+      [self.device unlockForConfiguration];
+
     } else {
-      errMsg = @"Camera has no flash or flash mode not supported";
+        NSLog(@"%@", error);
     }
   } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
+    NSLog(@"Camera has no flash or flash mode not supported");
   }
 }
 
 - (void)setTorchMode {
   NSError *error = nil;
-  NSString *errMsg;
 
-  // check session is started
-  if (self.session) {
-    // Let's save the setting even if we can't set it up on this camera.
-    //self.defaultFlashMode = flashMode;
+  // Let's save the setting even if we can't set it up on this camera.
+  //self.defaultFlashMode = flashMode;
 
-    if ([self.device hasTorch] && [self.device isTorchAvailable]) {
+  if ([self.device hasTorch] && [self.device isTorchAvailable]) {
 
-      if ([self.device lockForConfiguration:&error]) {
+    if ([self.device lockForConfiguration:&error]) {
 
-        if ([self.device isTorchModeSupported:1]) {
-          self.device.torchMode=1;  
-        } else if ([self.device isTorchModeSupported:2]) {
-          self.device.torchMode=2;
-        } else {
-          self.device.torchMode=0;
-        }
-        [self.device unlockForConfiguration];
+      if ([self.device isTorchModeSupported:1]) {
+        self.device.torchMode=1;
+      } else if ([self.device isTorchModeSupported:2]) {
+        self.device.torchMode=2;
       } else {
-          NSLog(@"%@", error);
+        self.device.torchMode=0;
       }
+      [self.device unlockForConfiguration];
     } else {
-      errMsg = @"Camera has no flash or flash mode not supported";
+        NSLog(@"%@", error);
     }
   } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
+    NSLog(@"Camera has no flash or flash mode not supported");
   }
 }
 
 - (void)setZoom:(CGFloat)desiredZoomFactor {
 
-  NSString *errMsg;
+  [self.device lockForConfiguration:nil];
+  self.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, self.device.activeFormat.videoMaxZoomFactor));
 
-  // check session is started
-  if (self.session) {
-    [self.device lockForConfiguration:nil];
-    self.videoZoomFactor = MAX(1.0, MIN(desiredZoomFactor, self.device.activeFormat.videoMaxZoomFactor));
-
-    [self.device setVideoZoomFactor:self.videoZoomFactor];
-    [self.device unlockForConfiguration];
-    NSLog(@"%zd zoom factor set", self.videoZoomFactor);
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  [self.device setVideoZoomFactor:self.videoZoomFactor];
+  [self.device unlockForConfiguration];
+  NSLog(@"%zd zoom factor set", self.videoZoomFactor);
 }
 
 - (CGFloat)getZoom {
 
-  NSString *errMsg;
-
-  // check session is started
-    
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    return videoDevice.videoZoomFactor;
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-    return 0;
-  }
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  return videoDevice.videoZoomFactor;
 }
 
 - (CGFloat)getMaxZoom {
 
-  NSString *errMsg;
-
-  // check session is started
-
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    return videoDevice.activeFormat.videoMaxZoomFactor;
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-    return 0;
-  }
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  return videoDevice.activeFormat.videoMaxZoomFactor;
 }
 
 - (NSArray *)getExposureModes {
 
-  NSString *errMsg;
-
-  // check session is started
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    NSMutableArray *exposureModes = [[NSMutableArray alloc] init];
-    if ([videoDevice isExposureModeSupported:0]) {
-      [exposureModes addObject:@"lock"];
-    };
-    if ([videoDevice isExposureModeSupported:1]) {
-      [exposureModes addObject:@"auto"];
-    };
-    if ([videoDevice isExposureModeSupported:2]) {
-      [exposureModes addObject:@"cotinuous"];
-    };
-    if ([videoDevice isExposureModeSupported:3]) {
-      [exposureModes addObject:@"custom"];
-    };
-    NSLog(@"%@", exposureModes);
-    return (NSArray *) exposureModes;
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  NSMutableArray *exposureModes = [[NSMutableArray alloc] init];
+  if ([videoDevice isExposureModeSupported:0]) {
+    [exposureModes addObject:@"lock"];
+  };
+  if ([videoDevice isExposureModeSupported:1]) {
+    [exposureModes addObject:@"auto"];
+  };
+  if ([videoDevice isExposureModeSupported:2]) {
+    [exposureModes addObject:@"cotinuous"];
+  };
+  if ([videoDevice isExposureModeSupported:3]) {
+    [exposureModes addObject:@"custom"];
+  };
+  NSLog(@"%@", exposureModes);
+  return (NSArray *) exposureModes;
 }
 
 - (NSString *) getExposureMode {
 
-  NSString *errMsg;
   NSString *exposureMode;
 
-  // check session is started 
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    switch (videoDevice.exposureMode) {
-      case 0:
-          exposureMode = @"lock";
-        break;
-      case 1:
-        exposureMode = @"auto";
-        break;
-      case 2:
-        exposureMode = @"continuous";
-        break;  
-      case 3:
-        exposureMode = @"custom";
-        break;
-      default:
-        exposureMode = @"unsupported";
-        errMsg = @"Mode not supported";
-    }
-    return exposureMode;
-  } else {
-    errMsg = @"Session is not started";
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  switch (videoDevice.exposureMode) {
+    case 0:
+        exposureMode = @"lock";
+      break;
+    case 1:
+      exposureMode = @"auto";
+      break;
+    case 2:
+      exposureMode = @"continuous";
+      break;
+    case 3:
+      exposureMode = @"custom";
+      break;
+    default:
+      exposureMode = @"unsupported";
+      NSLog(@"Mode not supported");
   }
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+
+  return exposureMode;
 }
 
 - (NSString *) setExposureMode:(NSString *)exposureMode {
 
   NSString *errMsg;
 
-  // check session is started
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    [self.device lockForConfiguration:nil];
-    if ([exposureMode isEqual:@"lock"]) {
-      if ([videoDevice isExposureModeSupported:0]) {
-        videoDevice.exposureMode = 0;
-        return exposureMode;
-      } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-      };
-    } else if ([exposureMode isEqual:@"auto"]) {
-      if ([videoDevice isExposureModeSupported:1]) {
-        videoDevice.exposureMode = 1;
-        return exposureMode;
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  [self.device lockForConfiguration:nil];
+  if ([exposureMode isEqual:@"lock"]) {
+    if ([videoDevice isExposureModeSupported:0]) {
+      videoDevice.exposureMode = 0;
+      return exposureMode;
     } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-      };
-    } else if ([exposureMode isEqual:@"continuous"]) {
-      if ([videoDevice isExposureModeSupported:2]) {
-        videoDevice.exposureMode = 2;
-        return exposureMode;
-      } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-      };  
-    } else if ([exposureMode isEqual:@"custom"]) {
-      if ([videoDevice isExposureModeSupported:3]) {
-        videoDevice.exposureMode = 3;
-        return exposureMode;
-      } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-      };
-    } else {
-        errMsg = @"Exposure mode not supported";
-        return @"ERR01";
-    } 
-    [self.device unlockForConfiguration];
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
+    };
+  } else if ([exposureMode isEqual:@"auto"]) {
+    if ([videoDevice isExposureModeSupported:1]) {
+      videoDevice.exposureMode = 1;
+      return exposureMode;
   } else {
-    errMsg = @"Session is not started";
-    return @"ERR02";
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
+    };
+  } else if ([exposureMode isEqual:@"continuous"]) {
+    if ([videoDevice isExposureModeSupported:2]) {
+      videoDevice.exposureMode = 2;
+      return exposureMode;
+    } else {
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
+    };
+  } else if ([exposureMode isEqual:@"custom"]) {
+    if ([videoDevice isExposureModeSupported:3]) {
+      videoDevice.exposureMode = 3;
+      return exposureMode;
+    } else {
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
+    };
+  } else {
+      errMsg = @"Exposure mode not supported";
+      return @"ERR01";
   }
+  [self.device unlockForConfiguration];
+
   if (errMsg) {
     NSLog(@"%@", errMsg);
   }
@@ -618,222 +488,161 @@
 
 - (NSArray *)getExposureCompensationRange {
 
-  NSString *errMsg;
-
-  // check session is started
-    
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    CGFloat maxExposureCompensation = videoDevice.maxExposureTargetBias;
-    CGFloat minExposureCompensation = videoDevice.minExposureTargetBias;
-    NSArray * exposureCompensationRange = [[NSArray alloc] initWithObjects: [NSNumber numberWithFloat:minExposureCompensation], [NSNumber numberWithFloat:maxExposureCompensation], nil];
-    return exposureCompensationRange;
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-    return 0;
-  }
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  CGFloat maxExposureCompensation = videoDevice.maxExposureTargetBias;
+  CGFloat minExposureCompensation = videoDevice.minExposureTargetBias;
+  NSArray * exposureCompensationRange = [[NSArray alloc] initWithObjects: [NSNumber numberWithFloat:minExposureCompensation], [NSNumber numberWithFloat:maxExposureCompensation], nil];
+  return exposureCompensationRange;
 }
 
 - (CGFloat)getExposureCompensation {
 
-  NSString *errMsg;
-
-  // check session is started
-
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    NSLog(@"getExposureCompensation: %zd", videoDevice.exposureTargetBias);
-    return videoDevice.exposureTargetBias;
-  } else {
-    errMsg = @"Session is not started";
-  }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-    return 0;
-  }
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  NSLog(@"getExposureCompensation: %zd", videoDevice.exposureTargetBias);
+  return videoDevice.exposureTargetBias;
 }
 
 - (void)setExposureCompensation:(CGFloat)exposureCompensation {
   NSError *error = nil;
-  NSString *errMsg;
 
-  // check session is started
-
-  if (self.session) {
-    if ([self.device lockForConfiguration:&error]) {
-      CGFloat exposureTargetBias = MAX(self.device.minExposureTargetBias, MIN(exposureCompensation, self.device.maxExposureTargetBias));
-      [self.device setExposureTargetBias:exposureTargetBias completionHandler:nil];
-      [self.device unlockForConfiguration];
-    } else {
-          NSLog(@"%@", error);
-    }  
+  if ([self.device lockForConfiguration:&error]) {
+    CGFloat exposureTargetBias = MAX(self.device.minExposureTargetBias, MIN(exposureCompensation, self.device.maxExposureTargetBias));
+    [self.device setExposureTargetBias:exposureTargetBias completionHandler:nil];
+    [self.device unlockForConfiguration];
   } else {
-    errMsg = @"Session is not started";
+    NSLog(@"%@", error);
   }
 
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
 }
 
 - (NSArray *)getSupportedWhiteBalanceModes {
 
-  NSString *errMsg;
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  NSLog(@"maxWhiteBalanceGain: %f", videoDevice.maxWhiteBalanceGain);
+  NSMutableArray * whiteBalanceModes = [[NSMutableArray alloc] init];
+  if ([videoDevice isWhiteBalanceModeSupported:0]) {
+    [whiteBalanceModes addObject:@"lock"];
+  };
+  if ([videoDevice isWhiteBalanceModeSupported:1]) {
+    [whiteBalanceModes addObject:@"auto"];
+  };
+  if ([videoDevice isWhiteBalanceModeSupported:2]) {
+    [whiteBalanceModes addObject:@"continuous"];
+  };
 
-  // check session is started
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    NSLog(@"maxWhiteBalanceGain: %f", videoDevice.maxWhiteBalanceGain);
-    NSMutableArray * whiteBalanceModes = [[NSMutableArray alloc] init];
-    if ([videoDevice isWhiteBalanceModeSupported:0]) {
-      [whiteBalanceModes addObject:@"lock"];
-    };
-    if ([videoDevice isWhiteBalanceModeSupported:1]) {
-      [whiteBalanceModes addObject:@"auto"];
-    };
-    if ([videoDevice isWhiteBalanceModeSupported:2]) {
-      [whiteBalanceModes addObject:@"continuous"];
-    };
-
-    NSEnumerator *enumerator = [self.colorTemperatures objectEnumerator];
-    TemperatureAndTint * wbTemperature;
-    while (wbTemperature =[ enumerator nextObject]) {
-      AVCaptureWhiteBalanceTemperatureAndTintValues temperatureAndTintValues;
-      temperatureAndTintValues.temperature = (wbTemperature.minTemperature + wbTemperature.maxTemperature) / 2;
-      temperatureAndTintValues.tint = wbTemperature.tint;
-      AVCaptureWhiteBalanceGains rgbGains = [videoDevice deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTintValues];
-      NSLog(@"mode: %@", wbTemperature.mode);
-      NSLog(@"minTemperature: %f", wbTemperature.minTemperature);
-      NSLog(@"maxTemperature: %f", wbTemperature.maxTemperature);
-      NSLog(@"blueGain: %f", rgbGains.blueGain);
-      NSLog(@"redGain: %f", rgbGains.redGain);
-      NSLog(@"greenGain: %f", rgbGains.greenGain);
-      if ((rgbGains.blueGain >= 1) &&
-          (rgbGains.blueGain <= videoDevice.maxWhiteBalanceGain) &&
-          (rgbGains.redGain >= 1) &&
-          (rgbGains.redGain <= videoDevice.maxWhiteBalanceGain) &&
-          (rgbGains.greenGain >= 1) &&
-          (rgbGains.greenGain <= videoDevice.maxWhiteBalanceGain)) {
-        [whiteBalanceModes addObject:wbTemperature.mode];
-      }
+  NSEnumerator *enumerator = [self.colorTemperatures objectEnumerator];
+  TemperatureAndTint * wbTemperature;
+  while (wbTemperature =[ enumerator nextObject]) {
+    AVCaptureWhiteBalanceTemperatureAndTintValues temperatureAndTintValues;
+    temperatureAndTintValues.temperature = (wbTemperature.minTemperature + wbTemperature.maxTemperature) / 2;
+    temperatureAndTintValues.tint = wbTemperature.tint;
+    AVCaptureWhiteBalanceGains rgbGains = [videoDevice deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTintValues];
+    NSLog(@"mode: %@", wbTemperature.mode);
+    NSLog(@"minTemperature: %f", wbTemperature.minTemperature);
+    NSLog(@"maxTemperature: %f", wbTemperature.maxTemperature);
+    NSLog(@"blueGain: %f", rgbGains.blueGain);
+    NSLog(@"redGain: %f", rgbGains.redGain);
+    NSLog(@"greenGain: %f", rgbGains.greenGain);
+    if ((rgbGains.blueGain >= 1) &&
+        (rgbGains.blueGain <= videoDevice.maxWhiteBalanceGain) &&
+        (rgbGains.redGain >= 1) &&
+        (rgbGains.redGain <= videoDevice.maxWhiteBalanceGain) &&
+        (rgbGains.greenGain >= 1) &&
+        (rgbGains.greenGain <= videoDevice.maxWhiteBalanceGain)) {
+      [whiteBalanceModes addObject:wbTemperature.mode];
     }
-    NSLog(@"%@", whiteBalanceModes);
-    return (NSArray *) whiteBalanceModes;
-  } else {
-    errMsg = @"Session is not started";
   }
-
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  NSLog(@"%@", whiteBalanceModes);
+  return (NSArray *) whiteBalanceModes;
 }
 
 - (NSString *) getWhiteBalanceMode {
 
-  NSString *errMsg;
   NSString *whiteBalanceMode;
 
-  // check session is started 
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    switch (videoDevice.whiteBalanceMode) {
-      case 0:
-          whiteBalanceMode = @"lock";
-          if (self.currentWhiteBalanceMode != nil) {
-            whiteBalanceMode = self.currentWhiteBalanceMode;    
-          }
-        break;
-      case 1:
-        whiteBalanceMode = @"auto";
-        break;
-      case 2:
-        whiteBalanceMode = @"continuous";
-        break;  
-      default:
-        whiteBalanceMode = @"unsupported";
-        errMsg = @"White balance mode not supported";
-    }
-    return whiteBalanceMode;
-  } else {
-    errMsg = @"Session is not started";
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  switch (videoDevice.whiteBalanceMode) {
+    case 0:
+        whiteBalanceMode = @"lock";
+        if (self.currentWhiteBalanceMode != nil) {
+          whiteBalanceMode = self.currentWhiteBalanceMode;
+        }
+      break;
+    case 1:
+      whiteBalanceMode = @"auto";
+      break;
+    case 2:
+      whiteBalanceMode = @"continuous";
+      break;
+    default:
+      whiteBalanceMode = @"unsupported";
+      NSLog(@"White balance mode not supported");
   }
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+
+  return whiteBalanceMode;
 }
 
 - (NSString *) setWhiteBalanceMode:(NSString *)whiteBalanceMode {
 
   NSString *errMsg;
 
-  // check session is started
-  
   NSLog(@"plugin White balance mode: %@", whiteBalanceMode);
-  if (self.session) {
-    AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-    [self.device lockForConfiguration:nil];
+  AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
+  [self.device lockForConfiguration:nil];
 
-    if ([whiteBalanceMode isEqual:@"lock"]) {
-      if ([videoDevice isWhiteBalanceModeSupported:0]) {
-        videoDevice.whiteBalanceMode = 0;
-        return whiteBalanceMode;
-      } else {
-        errMsg = @"White balance mode not supported";
-        return @"ERR01";
-      };
-    } else if ([whiteBalanceMode isEqual:@"auto"]) {
-      if ([videoDevice isWhiteBalanceModeSupported:1]) {
-        videoDevice.whiteBalanceMode = 1;
-        return whiteBalanceMode;
+  if ([whiteBalanceMode isEqual:@"lock"]) {
+    if ([videoDevice isWhiteBalanceModeSupported:0]) {
+      videoDevice.whiteBalanceMode = 0;
+      return whiteBalanceMode;
     } else {
-        errMsg = @"White balance mode not supported";
-        return @"ERR01";
-      };
-    } else if ([whiteBalanceMode isEqual:@"continuous"]) {
-      if ([videoDevice isWhiteBalanceModeSupported:2]) {
-        videoDevice.whiteBalanceMode = 2;
-        return whiteBalanceMode;
-      } else {
-        errMsg = @"White balance mode not supported";
-        return @"ERR01";
-      };
-    } else {
-        NSLog(@"Additional modes for %@", whiteBalanceMode);
-        TemperatureAndTint * temperatureForWhiteBalanceSetting = [self.colorTemperatures objectForKey:whiteBalanceMode];
-        if (temperatureForWhiteBalanceSetting != nil) {
-          AVCaptureWhiteBalanceTemperatureAndTintValues temperatureAndTintValues;
-          temperatureAndTintValues.temperature = (temperatureForWhiteBalanceSetting.minTemperature + temperatureForWhiteBalanceSetting.maxTemperature) / 2;
-          temperatureAndTintValues.tint = temperatureForWhiteBalanceSetting.tint;
-          AVCaptureWhiteBalanceGains rgbGains = [videoDevice deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTintValues];
-          if ((rgbGains.blueGain >= 1) &&
-             (rgbGains.blueGain <= videoDevice.maxWhiteBalanceGain) &&
-             (rgbGains.redGain >= 1) &&
-             (rgbGains.redGain <= videoDevice.maxWhiteBalanceGain) &&
-             (rgbGains.greenGain >= 1) &&
-             (rgbGains.greenGain <= videoDevice.maxWhiteBalanceGain)) {
-          
-            [videoDevice setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:nil];
-            self.currentWhiteBalanceMode = whiteBalanceMode;
-            return self.currentWhiteBalanceMode;
-          } else {
-            errMsg = @"White balance mode not supported";
-            return @"ERR01";            
-          }
-        } else {
-        errMsg = @"White balance mode not supported";
-        return @"ERR01";
-      }
-    } 
-    [self.device unlockForConfiguration];
+      errMsg = @"White balance mode not supported";
+      return @"ERR01";
+    };
+  } else if ([whiteBalanceMode isEqual:@"auto"]) {
+    if ([videoDevice isWhiteBalanceModeSupported:1]) {
+      videoDevice.whiteBalanceMode = 1;
+      return whiteBalanceMode;
   } else {
-    errMsg = @"Session is not started";
-    return @"ERR02";
+      errMsg = @"White balance mode not supported";
+      return @"ERR01";
+    };
+  } else if ([whiteBalanceMode isEqual:@"continuous"]) {
+    if ([videoDevice isWhiteBalanceModeSupported:2]) {
+      videoDevice.whiteBalanceMode = 2;
+      return whiteBalanceMode;
+    } else {
+      errMsg = @"White balance mode not supported";
+      return @"ERR01";
+    };
+  } else {
+      NSLog(@"Additional modes for %@", whiteBalanceMode);
+      TemperatureAndTint * temperatureForWhiteBalanceSetting = [self.colorTemperatures objectForKey:whiteBalanceMode];
+      if (temperatureForWhiteBalanceSetting != nil) {
+        AVCaptureWhiteBalanceTemperatureAndTintValues temperatureAndTintValues;
+        temperatureAndTintValues.temperature = (temperatureForWhiteBalanceSetting.minTemperature + temperatureForWhiteBalanceSetting.maxTemperature) / 2;
+        temperatureAndTintValues.tint = temperatureForWhiteBalanceSetting.tint;
+        AVCaptureWhiteBalanceGains rgbGains = [videoDevice deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTintValues];
+        if ((rgbGains.blueGain >= 1) &&
+           (rgbGains.blueGain <= videoDevice.maxWhiteBalanceGain) &&
+           (rgbGains.redGain >= 1) &&
+           (rgbGains.redGain <= videoDevice.maxWhiteBalanceGain) &&
+           (rgbGains.greenGain >= 1) &&
+           (rgbGains.greenGain <= videoDevice.maxWhiteBalanceGain)) {
+
+          [videoDevice setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:nil];
+          self.currentWhiteBalanceMode = whiteBalanceMode;
+          return self.currentWhiteBalanceMode;
+        } else {
+          errMsg = @"White balance mode not supported";
+          return @"ERR01";
+        }
+      } else {
+      errMsg = @"White balance mode not supported";
+      return @"ERR01";
+    }
   }
+  [self.device unlockForConfiguration];
+
   if (errMsg) {
     NSLog(@"%@", errMsg);
   }
@@ -841,35 +650,24 @@
 
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint {
 
-  NSString *errMsg;
+  [self.device lockForConfiguration:nil];
 
-  // check session is started
-  if (self.session) {
-    [self.device lockForConfiguration:nil];
+  CGRect screenRect = [[UIScreen mainScreen] bounds];
+  CGFloat screenWidth = screenRect.size.width;
+  CGFloat screenHeight = screenRect.size.height;
+  CGFloat focus_x = xPoint/screenWidth;
+  CGFloat focus_y = yPoint/screenHeight;
 
-    CGRect screenRect = [[UIScreen mainScreen] bounds];
-    CGFloat screenWidth = screenRect.size.width;
-    CGFloat screenHeight = screenRect.size.height;
-    CGFloat focus_x = xPoint/screenWidth;
-    CGFloat focus_y = yPoint/screenHeight;
-
-    if ([self.device isFocusModeSupported:AVCaptureFocusModeAutoFocus]){
-      [self.device setFocusPointOfInterest:CGPointMake(focus_x,focus_y)];
-      [self.device setFocusMode:AVCaptureFocusModeAutoFocus];
-    }
-    if ([self.device isExposureModeSupported:AVCaptureExposureModeAutoExpose]){
-      [self.device setExposurePointOfInterest:CGPointMake(focus_x,focus_y)];
-      [self.device setExposureMode:AVCaptureExposureModeAutoExpose];
-    }
-
-    [self.device unlockForConfiguration];
-  } else {
-    errMsg = @"Session is not started";
+  if ([self.device isFocusModeSupported:AVCaptureFocusModeAutoFocus]){
+    [self.device setFocusPointOfInterest:CGPointMake(focus_x,focus_y)];
+    [self.device setFocusMode:AVCaptureFocusModeAutoFocus];
+  }
+  if ([self.device isExposureModeSupported:AVCaptureExposureModeAutoExpose]){
+    [self.device setExposurePointOfInterest:CGPointMake(focus_x,focus_y)];
+    [self.device setExposureMode:AVCaptureExposureModeAutoExpose];
   }
 
-  if (errMsg) {
-    NSLog(@"%@", errMsg);
-  }
+  [self.device unlockForConfiguration];
 }
 
 - (void)checkDeviceAuthorizationStatus {

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -261,33 +261,33 @@
   if ([focusMode isEqual:@"fixed"]) {
     if ([videoDevice isFocusModeSupported:0]) {
       videoDevice.focusMode = 0;
-      return focusMode;
     } else {
       errMsg = @"Focus mode not supported";
-      return @"ERR01";
     };
   } else if ([focusMode isEqual:@"auto"]) {
     if ([videoDevice isFocusModeSupported:1]) {
       videoDevice.focusMode = 1;
-      return focusMode;
-  } else {
+    } else {
       errMsg = @"Focus mode not supported";
-      return @"ERR01";
     };
   } else if ([focusMode isEqual:@"continuous"]) {
     if ([videoDevice isFocusModeSupported:2]) {
       videoDevice.focusMode = 2;
-      return focusMode;
     } else {
       errMsg = @"Focus mode not supported";
-      return @"ERR01";
     };
   } else {
-      errMsg = @"Exposure mode not supported";
-      return @"ERR01";
+    errMsg = @"Exposure mode not supported";
   }
 
   [self.device unlockForConfiguration];
+
+  if (errMsg) {
+    NSLog(@"%@", errMsg);
+    return @"ERR01";
+  }
+
+  return focusMode;
 }
 
 - (NSArray *)getFlashModes {
@@ -443,47 +443,43 @@
 
   AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
   [self.device lockForConfiguration:nil];
+
   if ([exposureMode isEqual:@"lock"]) {
     if ([videoDevice isExposureModeSupported:0]) {
       videoDevice.exposureMode = 0;
-      return exposureMode;
     } else {
       errMsg = @"Exposure mode not supported";
-      return @"ERR01";
     };
   } else if ([exposureMode isEqual:@"auto"]) {
     if ([videoDevice isExposureModeSupported:1]) {
       videoDevice.exposureMode = 1;
-      return exposureMode;
-  } else {
+    } else {
       errMsg = @"Exposure mode not supported";
-      return @"ERR01";
     };
   } else if ([exposureMode isEqual:@"continuous"]) {
     if ([videoDevice isExposureModeSupported:2]) {
       videoDevice.exposureMode = 2;
-      return exposureMode;
     } else {
       errMsg = @"Exposure mode not supported";
-      return @"ERR01";
     };
   } else if ([exposureMode isEqual:@"custom"]) {
     if ([videoDevice isExposureModeSupported:3]) {
       videoDevice.exposureMode = 3;
-      return exposureMode;
     } else {
       errMsg = @"Exposure mode not supported";
-      return @"ERR01";
     };
   } else {
-      errMsg = @"Exposure mode not supported";
-      return @"ERR01";
+    errMsg = @"Exposure mode not supported";
   }
+
   [self.device unlockForConfiguration];
 
   if (errMsg) {
     NSLog(@"%@", errMsg);
+    return @"ERR01";
   }
+
+  return exposureMode;
 }
 
 - (NSArray *)getExposureCompensationRange {
@@ -593,26 +589,20 @@
   if ([whiteBalanceMode isEqual:@"lock"]) {
     if ([videoDevice isWhiteBalanceModeSupported:0]) {
       videoDevice.whiteBalanceMode = 0;
-      return whiteBalanceMode;
     } else {
       errMsg = @"White balance mode not supported";
-      return @"ERR01";
     };
   } else if ([whiteBalanceMode isEqual:@"auto"]) {
     if ([videoDevice isWhiteBalanceModeSupported:1]) {
       videoDevice.whiteBalanceMode = 1;
-      return whiteBalanceMode;
   } else {
       errMsg = @"White balance mode not supported";
-      return @"ERR01";
     };
   } else if ([whiteBalanceMode isEqual:@"continuous"]) {
     if ([videoDevice isWhiteBalanceModeSupported:2]) {
       videoDevice.whiteBalanceMode = 2;
-      return whiteBalanceMode;
     } else {
       errMsg = @"White balance mode not supported";
-      return @"ERR01";
     };
   } else {
       NSLog(@"Additional modes for %@", whiteBalanceMode);
@@ -631,21 +621,21 @@
 
           [videoDevice setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:nil];
           self.currentWhiteBalanceMode = whiteBalanceMode;
-          return self.currentWhiteBalanceMode;
         } else {
           errMsg = @"White balance mode not supported";
-          return @"ERR01";
         }
       } else {
       errMsg = @"White balance mode not supported";
-      return @"ERR01";
     }
   }
   [self.device unlockForConfiguration];
 
   if (errMsg) {
     NSLog(@"%@", errMsg);
+    return @"ERR01";
   }
+
+  return whiteBalanceMode;
 }
 
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint {


### PR DESCRIPTION
This four commits fix several bugs and discrepancies.

1. Make all "session not started" messages the same
2. All the getter/setter methods were bugged for two reasons:
     - the session check was unnecessary as it is already checked in `sessionManager.m`
     - they were returning `void` when the check was negative which would crash the app if actually called before the camera is started.
3. A few methods were never calling `unlockForConfiguration ` because they were returning beforehand.
4. The `switchCamera` and `startCamera`methods were calling the successCallback before the actions went through and are now properly async. 

The following codes would have returned the wrong flashModes and sizes (using Ionic).

```Typescript
    this.cameraPreview.switchCamera().then(()=> {
      this.cameraPreview.getSupportedFlashModes().then(success => console.log(success));
      this.cameraPreview.getSupportedPictureSizes().then(success => console.log(success));
    });
```

The callback fired immediately and before the camera switched, and returned the wrong flash modes and image sizes (from the previous camera).