### PR TITLE
iOS: fix session stopped twice

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -81,9 +81,8 @@
   if(self.sessionManager != nil) {
     [self.cameraRenderController.view removeFromSuperview];
     [self.cameraRenderController removeFromParentViewController];
-    self.cameraRenderController = nil;
 
-    [self.sessionManager.session stopRunning];
+    self.cameraRenderController = nil;
     self.sessionManager = nil;
 
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
The app sometimes hangs for several seconds when stopping the camera in iOS, this is because `[session stopRunning]` is called twice.

It is called in [`CameraRenderController.m`](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/blob/master/src/ios/CameraRenderController.m#L95-L98)

`viewWillDisappear ` is always called when `[self.cameraRenderController.view removeFromSuperview]` is called [here](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/blob/master/src/ios/CameraPreview.m#L82) making the inline call redundant and blocking.


