### PR TITLE
TapToFocus option for android.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ let options = {
   camera: CameraPreview.CAMERA_DIRECTION.BACK,
   toBack: false,
   tapPhoto: true,
-  tapFocus: true,
+  tapFocus: false,
   previewDrag: false
 };
 
@@ -93,6 +93,8 @@ html, body, .ion-app, .ion-content {
   background-color: transparent;
 }
 ```
+
+When both tapFocus and tapPhoto are true, the camera will focus, and take a picture as soon as the camera is done focusing.
 
 ### stopCamera([successCallback, errorCallback])
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ All options stated are optional and will default to values here
 * `camera` - See <code>[CAMERA_DIRECTION](#camera_Settings.CameraDirection)</code> - Defaults to front camera/code>
 * `toBack` - Defaults to false - Set to true if you want your html in front of your preview
 * `tapPhoto` - Defaults to true - Does not work if toBack is set to false in which case you use the takePicture method
+* `tapFocus` - Defaults to false - Allows the user to tap to focus, when the view is in the foreground
 * `previewDrag` - Defaults to false - Does not work if toBack is set to false
 
 ```javascript
@@ -78,6 +79,7 @@ let options = {
   camera: CameraPreview.CAMERA_DIRECTION.BACK,
   toBack: false,
   tapPhoto: true,
+  tapFocus: true,
   previewDrag: false
 };
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -78,7 +78,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
     if (START_CAMERA_ACTION.equals(action)) {
       if (cordova.hasPermission(permissions[0])) {
-        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), callbackContext);
+        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), args.getBoolean(9), callbackContext);
       } else {
         this.execCallback = callbackContext;
         this.execArgs = args;
@@ -151,7 +151,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       }
     }
     if (requestCode == CAM_REQ_CODE) {
-      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execCallback);
+      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execArgs.getBoolean(9), this.execCallback);
     }
   }
 
@@ -208,7 +208,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, CallbackContext callbackContext) {
+    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
     if (fragment != null) {
       callbackContext.error("Camera already started");
@@ -222,6 +222,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     fragment.defaultCamera = defaultCamera;
     fragment.tapToTakePicture = tapToTakePicture;
     fragment.dragEnabled = dragEnabled;
+    fragment.tapToFocus = tapFocus;
 
     DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
     // offset
@@ -799,7 +800,15 @@ private boolean getSupportedFocusModes(CallbackContext callbackContext) {
 
     setFocusCallbackContext = callbackContext;
 
-    fragment.setFocusArea(pointX, pointY);
+    fragment.setFocusArea(pointX, pointY, new Camera.AutoFocusCallback() {
+      public void onAutoFocus(boolean success, Camera camera) {
+        if (success) {
+          onFocusSet(pointX, pointY);
+        } else {
+          onFocusSetError("fragment.setFocusArea() failed");
+        }
+      }
+    });
     return true;
   }
 

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -5,7 +5,7 @@
 #import "CameraSessionManager.h"
 #import "CameraRenderController.h"
 
-@interface CameraPreview : CDVPlugin <TakePictureDelegate>
+@interface CameraPreview : CDVPlugin <TakePictureDelegate, FocusDelegate>
 
 - (void) startCamera:(CDVInvokedUrlCommand*)command;
 - (void) stopCamera:(CDVInvokedUrlCommand*)command;
@@ -39,6 +39,8 @@
 
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(CGFloat) quality;
 - (void) invokeTakePicture;
+
+- (void) invokeTapToFocus:(CGPoint) point;
 
 @property (nonatomic) CameraSessionManager *sessionManager;
 @property (nonatomic) CameraRenderController *cameraRenderController;

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -36,7 +36,6 @@
 - (void) getWhiteBalanceMode:(CDVInvokedUrlCommand*)command;
 - (void) setWhiteBalanceMode:(CDVInvokedUrlCommand*)command;
 
-
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(CGFloat) quality;
 - (void) invokeTakePicture;
 

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -635,6 +635,11 @@
   [self invokeTakePicture:0.0 withHeight:0.0 withQuality:0.85];
 }
 
+- (void) invokeTakePictureOnFocus {
+    // the sessionManager will call onFocus, as soon as the camera is done with focussing.
+  [self.sessionManager takePictureOnFocus];
+}
+
 - (void) invokeTakePicture:(CGFloat) width withHeight:(CGFloat) height withQuality:(CGFloat) quality{
     AVCaptureConnection *connection = [self.sessionManager.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
     [self.sessionManager.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler:^(CMSampleBufferRef sampleBuffer, NSError *error) {

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -31,6 +31,8 @@
     BOOL tapToTakePicture = (BOOL)[command.arguments[5] boolValue];
     BOOL dragEnabled = (BOOL)[command.arguments[6] boolValue];
     BOOL toBack = (BOOL)[command.arguments[7] boolValue];
+    CGFloat alpha = (CGFloat)[command.arguments[8] floatValue];
+    BOOL tapToFocus = (BOOL) [command.arguments[9] boolValue];
 
     // Create the session manager
     self.sessionManager = [[CameraSessionManager alloc] init];
@@ -39,6 +41,7 @@
     self.cameraRenderController = [[CameraRenderController alloc] init];
     self.cameraRenderController.dragEnabled = dragEnabled;
     self.cameraRenderController.tapToTakePicture = tapToTakePicture;
+    self.cameraRenderController.tapToFocus = tapToFocus;
     self.cameraRenderController.sessionManager = self.sessionManager;
     self.cameraRenderController.view.frame = CGRectMake(x, y, width, height);
     self.cameraRenderController.delegate = self;
@@ -55,7 +58,7 @@
       [self.webView.superview addSubview:self.cameraRenderController.view];
       [self.webView.superview bringSubviewToFront:self.webView];
     } else {
-      self.cameraRenderController.view.alpha = (CGFloat)[command.arguments[8] floatValue];
+      self.cameraRenderController.view.alpha = alpha;
       [self.webView.superview insertSubview:self.cameraRenderController.view aboveSubview:self.webView];
     }
 
@@ -622,6 +625,10 @@
   UIGraphicsEndImageContext();
 
   return rotatedCGImage;
+}
+
+- (void) invokeTapToFocus:(CGPoint)point {
+  [self.sessionManager tapToFocus:point.x yPoint:point.y];
 }
 
 - (void) invokeTakePicture {

--- a/src/ios/CameraRenderController.h
+++ b/src/ios/CameraRenderController.h
@@ -11,13 +11,14 @@
 
 @protocol TakePictureDelegate
 - (void) invokeTakePicture;
+- (void) invokeTakePictureOnFocus;
 @end;
 
 @protocol FocusDelegate
 - (void) invokeTapToFocus:(CGPoint)point;
 @end;
 
-@interface CameraRenderController : UIViewController <AVCaptureVideoDataOutputSampleBufferDelegate> {
+@interface CameraRenderController : UIViewController <AVCaptureVideoDataOutputSampleBufferDelegate, OnFocusDelegate> {
   GLuint _renderBuffer;
   CVOpenGLESTextureCacheRef _videoTextureCache;
   CVOpenGLESTextureRef _lumaTexture;

--- a/src/ios/CameraRenderController.h
+++ b/src/ios/CameraRenderController.h
@@ -13,6 +13,10 @@
 - (void) invokeTakePicture;
 @end;
 
+@protocol FocusDelegate
+- (void) invokeTapToFocus:(CGPoint)point;
+@end;
+
 @interface CameraRenderController : UIViewController <AVCaptureVideoDataOutputSampleBufferDelegate> {
   GLuint _renderBuffer;
   CVOpenGLESTextureCacheRef _videoTextureCache;
@@ -26,6 +30,7 @@
 @property (nonatomic) NSLock *renderLock;
 @property BOOL dragEnabled;
 @property BOOL tapToTakePicture;
+@property BOOL tapToFocus;
 @property (nonatomic, assign) id delegate;
 
 @end

--- a/src/ios/CameraRenderController.m
+++ b/src/ios/CameraRenderController.m
@@ -53,13 +53,23 @@
     [self.view addGestureRecognizer:drag];
   }
 
-  if (self.tapToTakePicture) {
+  if (self.tapToFocus && self.tapToTakePicture){
+    //tap to focus and take picture
+    UITapGestureRecognizer *tapToFocusAndTakePicture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector (handleFocusAndTakePictureTap:)];
+    [self.view addGestureRecognizer:tapToFocusAndTakePicture];
+
+  } else if (self.tapToFocus){
+    // tap to focus
+    UITapGestureRecognizer *tapToFocusGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector (handleFocusTap:)];
+    [self.view addGestureRecognizer:tapToFocusGesture];
+
+  } else if (self.tapToTakePicture) {
     //tap to take picture
     UITapGestureRecognizer *takePictureTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTakePictureTap:)];
     [self.view addGestureRecognizer:takePictureTap];
   }
 
-  self.view.userInteractionEnabled = self.dragEnabled || self.tapToTakePicture;
+  self.view.userInteractionEnabled = self.dragEnabled || self.tapToTakePicture || self.tapToFocus;
 }
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -98,9 +108,26 @@
       });
 }
 
+- (void) handleFocusAndTakePictureTap:(UITapGestureRecognizer*)recognizer {
+  NSLog(@"handleFocusAndTakePictureTap");
+  [self handleFocusTap:recognizer];
+  [self performSelector:@selector(handleTakePictureTap:)
+        withObject:recognizer
+        afterDelay:1];
+}
+
 - (void) handleTakePictureTap:(UITapGestureRecognizer*)recognizer {
   NSLog(@"handleTakePictureTap");
   [self.delegate invokeTakePicture];
+}
+
+- (void) handleFocusTap:(UITapGestureRecognizer*)recognizer {
+  NSLog(@"handleTapFocusTap");
+
+  if (recognizer.state == UIGestureRecognizerStateEnded)    {
+      CGPoint point = [recognizer locationInView:self.view];
+      [self.delegate invokeTapToFocus:point];
+  }
 }
 
 - (IBAction)handlePan:(UIPanGestureRecognizer *)recognizer {

--- a/src/ios/CameraRenderController.m
+++ b/src/ios/CameraRenderController.m
@@ -110,10 +110,12 @@
 
 - (void) handleFocusAndTakePictureTap:(UITapGestureRecognizer*)recognizer {
   NSLog(@"handleFocusAndTakePictureTap");
+
+  // let the delegate take an image, the next time the image is in focus.
+  [self.delegate invokeTakePictureOnFocus];
+
+  // let the delegate focus on the tapped point.
   [self handleFocusTap:recognizer];
-  [self performSelector:@selector(handleTakePictureTap:)
-        withObject:recognizer
-        afterDelay:1];
 }
 
 - (void) handleTakePictureTap:(UITapGestureRecognizer*)recognizer {
@@ -125,15 +127,19 @@
   NSLog(@"handleTapFocusTap");
 
   if (recognizer.state == UIGestureRecognizerStateEnded)    {
-      CGPoint point = [recognizer locationInView:self.view];
-      [self.delegate invokeTapToFocus:point];
+    CGPoint point = [recognizer locationInView:self.view];
+    [self.delegate invokeTapToFocus:point];
   }
+}
+
+- (void) onFocus{
+  [self.delegate invokeTakePicture];
 }
 
 - (IBAction)handlePan:(UIPanGestureRecognizer *)recognizer {
         CGPoint translation = [recognizer translationInView:self.view];
         recognizer.view.center = CGPointMake(recognizer.view.center.x + translation.x,
-            recognizer.view.center.y + translation.y);
+                                             recognizer.view.center.y + translation.y);
         [recognizer setTranslation:CGPointMake(0, 0) inView:self.view];
 }
 

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -2,6 +2,10 @@
 #import <AVFoundation/AVFoundation.h>
 #import "TemperatureAndTint.h"
 
+@protocol OnFocusDelegate
+- (void) onFocus;
+@end;
+
 @interface CameraSessionManager : NSObject
 
 - (CameraSessionManager *)init;
@@ -28,6 +32,7 @@
 - (NSString *) setWhiteBalanceMode:(NSString *)whiteBalanceMode;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
+- (void) takePictureOnFocus;
 - (void) setTorchMode;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -648,6 +648,23 @@
   return whiteBalanceMode;
 }
 
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    // removes the observer, when the camera is done focussing.
+    if( [keyPath isEqualToString:@"adjustingFocus"] ){
+        BOOL adjustingFocus = [[change objectForKey:NSKeyValueChangeNewKey] isEqualToNumber:[NSNumber numberWithInt:1]];
+        if(!adjustingFocus){
+            [self.device removeObserver:self forKeyPath:@"adjustingFocus"];
+            [self.delegate onFocus];
+        }
+    }
+}
+
+- (void) takePictureOnFocus{
+    // add an observer, when takePictureOnFocus is requested.
+    int flag = NSKeyValueObservingOptionNew;
+    [self.device addObserver:self forKeyPath:@"adjustingFocus" options:flag context:nil];
+}
+
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint {
 
   [self.device lockForConfiguration:nil];

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -20,13 +20,18 @@ CameraPreview.startCamera = function(options, onSuccess, onError) {
     if (typeof(options.tapPhoto) === 'undefined') {
         options.tapPhoto = true;
     }
+
+    if (typeof (options.tapFocus) == 'undefined') {
+      options.tapFocus = true;
+    }
+
     options.previewDrag = options.previewDrag || false;
     options.toBack = options.toBack || false;
     if (typeof(options.alpha) === 'undefined') {
         options.alpha = 1;
     }
 
-    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha]);
+    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha, options.tapFocus]);
 };
 
 CameraPreview.stopCamera = function(onSuccess, onError) {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -22,7 +22,7 @@ CameraPreview.startCamera = function(options, onSuccess, onError) {
     }
 
     if (typeof (options.tapFocus) == 'undefined') {
-      options.tapFocus = true;
+      options.tapFocus = false;
     }
 
     options.previewDrag = options.previewDrag || false;


### PR DESCRIPTION
Hello :)

I found that it was not possible to use CameraPreview.tapToFocus(), when the CameraActivity was in front of cordovas WebView, because touch events would not be propagated to the webview. Our javascript application would never know that the user tapped on the camera feed.

I added the property _tapFocus_ to the options in CameraPreview.startCamera(options .. ), allowing the user to focus the camera, when the plugin is running in front of the webView.

When both options.tapPhoto and options.tapFocus are true, the camera will first focus, and then take a picture.
When only tapFocus is true, the camera will simply focus, but not take a picture.

I have tested this change on a Nexus 5x.

Please let me know if any additional changes are needed.

Best regards,
Lukas Walther

