### PR TITLE
Android: start camera callback firing too early

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -52,6 +52,7 @@ public class CameraActivity extends Fragment {
     void onPictureTakenError(String message);
     void onFocusSet(int pointX, int pointY);
     void onFocusSetError(String message);
+    void onCameraStarted();
   }
 
   private CameraPreviewListener eventListener;
@@ -224,6 +225,7 @@ public class CameraActivity extends Fragment {
 
     if(mPreview.mPreviewSize == null){
       mPreview.setCamera(mCamera, cameraCurrentlyLocked);
+      eventListener.onCameraStarted();
     } else {
       mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
       mCamera.startPreview();

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -63,6 +63,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   private CameraActivity fragment;
   private CallbackContext takePictureCallbackContext;
   private CallbackContext setFocusCallbackContext;
+  private CallbackContext startCameraCallbackContext;
 
   private CallbackContext execCallback;
   private JSONArray execArgs;
@@ -234,7 +235,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
     fragment.setRect(computedX, computedY, computedWidth, computedHeight);
 
-    final CallbackContext cb = callbackContext;
+    startCameraCallbackContext = callbackContext;
 
     cordova.getActivity().runOnUiThread(new Runnable() {
       @Override
@@ -265,12 +266,18 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
         fragmentTransaction.add(containerView.getId(), fragment);
         fragmentTransaction.commit();
-
-        cb.success("Camera started");
       }
     });
 
     return true;
+  }
+
+  public void onCameraStarted() {
+    Log.d(TAG, "Camera started");
+
+    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Camera started");
+    pluginResult.setKeepCallback(true);
+    startCameraCallbackContext.sendPluginResult(pluginResult);
   }
 
   private boolean takePicture(int width, int height, int quality, CallbackContext callbackContext) {


### PR DESCRIPTION
The success callback of Start Camera was firing too early.

The following code returned two "camera not started" errors (using ionic).

```typescript
    this.cameraPreview.startCamera().then(()=> {
      this.cameraPreview.getSupportedFlashModes().then(()=> {}, error => console.error(error));
      this.cameraPreview.getSupportedPictureSizes().then(()=> {}, error => console.error(error));
    });
```