### PR TITLE
Extend and update typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "Apache 2.0",
   "homepage": "https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview",
+  "typings": "typescript/CameraPreview.d.ts",
   "dependencies": {
     "cordova": "*"
   },

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -1,28 +1,64 @@
+type CameraPreviewErrorHandler = (err: any) => any;
+type CameraPreviewSuccessHandler = (data: any) => any;
+
+type CameraPreviewCameraDirection = 'back'|'front';
+type CameraPreviewColorEffect = 'aqua'|'blackboard'|'mono'|'negative'|'none'|'posterize'|'sepia'|'solarize'|'whiteboard';
+type CameraPreviewExposureMode = 'lock'|'auto'|'continuous'|'custom';
+type CameraPreviewFlashMode = 'off'|'on'|'auto'|'red-eye'|'torch';
+type CameraPreviewFocusMode = 'fixed'|'auto'|'continuous'|'continuous-picture'|'continuous-video'|'edof'|'infinity'|'macro';
+type CameraPreviewWhiteBalanceMode = 'lock'|'auto'|'continuous'|'incandescent'|'cloudy-daylight'|'daylight'|'fluorescent'|'shade'|'twilight'|'warm-fluorescent';
+
+interface CameraPreviewStartCameraOptions {
+  alpha?: number;
+  camera?: CameraPreviewCameraDirection|string;
+  height?: number;
+  previewDrag?: boolean;
+  tapFocus?: boolean;
+  tapPhoto?: boolean;
+  toBack?: boolean;
+  width?: number;
+  x?: number;
+  y?: number;
+}
+
+interface CameraPreviewTakePictureOptions {
+  height?: number;
+  quality?: number;
+  width?: number;
+}
+
+interface CameraPreviewPreviewSizeDimension {
+  height?: number;
+  width?: number;
+}
+
 interface CameraPreview {
-  startCamera(options?:any, onSuccess?:any, onError?:any):any;
-  stopCamera(onSuccess?:any, onError?:any):any;
-  switchCamera(onSuccess?:any, onError?:any):any;
-  hide(onSuccess?:any, onError?:any):any;
-  show(onSuccess?:any, onError?:any):any;
-  takePicture(options?:any, onSuccess?:any, onError?:any):any;
-  setColorEffect(effect:string, onSuccess?:any, onError?:any):any;
-  getSupportedFocusMode(onSuccess?:any, onError?:any):any;
-  getFocusMode(onSuccess?:any, onError?:any):any;
-  setFocusMode(onSuccess?:any, onError?:any):any;
-  setZoom(zoom?:any, onSuccess?:any, onError?:any):any;
-  getMaxZoom(onSuccess?:any, onError?:any):any;
-  getZoom(onSuccess?:any, onError?:any):any;
-  setPreviewSize(dimensions?:any, onSuccess?:any, onError?:any):any;
-  getSupportedPictureSizes(onSuccess?:any, onError?:any):any;
-  getExposureModes(onSuccess?:any, onError?:any):any;
-  getExposureMode(onSuccess?:any, onError?:any):any;
-  setExposureMode(exposureMode?:any, onSuccess?:any, onError?:any):any;
-  getExposureCompensation(onSuccess?:any, onError?:any):any;
-  setExposureCompensation(exposureCompensation?:any, onSuccess?:any, onError?:any):any;
-  getExposureCompensationRange(onSuccess?:any, onError?:any):any;
-  getSupportedFlashModes(onSuccess?:any, onError?:any):any;
-  setFlashMode(flashMode:string, onSuccess?:any, onError?:any):any;
-  getSupportedWhiteBalanceModes(onSuccess?:any, onError?:any):any;
-  getSupportedWhiteBalanceMode(onSuccess?:any, onError?:any):any;
-  setWhiteBalanceMode(whiteBalanceMode?:any, onSuccess?:any, onError?:any):any;
+  startCamera(options?:CameraPreviewStartCameraOptions, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  stopCamera(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  switchCamera(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  hide(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  show(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  takePicture(options?:CameraPreviewTakePictureOptions|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
+  setColorEffect(effect:CameraPreviewColorEffect|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setZoom(zoom?:number, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getMaxZoom(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedFocusMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getZoom(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setPreviewSize(dimensions?:CameraPreviewPreviewSizeDimension|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedPictureSizes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedFlashModes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setFlashMode(flashMode:CameraPreviewFlashMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedFocusModes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getFocusMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setFocusMode(focusMode?: CameraPreviewFocusMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  tapToFocus(xPoint?: number, yPoint?: number, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getExposureModes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getExposureMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setExposureMode(exposureMode?:CameraPreviewExposureMode, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getExposureCompensation(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setExposureCompensation(exposureCompensation?:number, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getExposureCompensationRange(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedWhiteBalanceModes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  getSupportedWhiteBalanceMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  setWhiteBalanceMode(whiteBalanceMode?:CameraPreviewWhiteBalanceMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
 }

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -93,7 +93,7 @@ CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError) {
     dimensions.width = dimensions.width || window.screen.width;
     dimensions.height = dimensions.height || window.screen.height;
 
-    return exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
+    exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
 };
 
 CameraPreview.getSupportedPictureSizes = function(onSuccess, onError) {


### PR DESCRIPTION
A few additions and fixes for the TypeScript typings.

- Add `typings` to `package.json` so tools can autodetect the `CameraPreview.d.ts` file.
- Switched to strong typing to all arguments and return values (no more use of *any*).
- Added missing methods.
- Removed a `return` from the regular JavaScript file, as `exec` doesn't return anything so that looks like it doesn't belong there.