### PR TITLE
Added listener for the back button event to prevent app from closing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ If you are developing for iOS 10+ you must also add the following to your config
 </gap:config-file>
 ```
 
+### Android Quirks (older devices)
+When using the plugin for older devices, the camera preview will take the focus inside the app once initialized.
+In order to prevent the app from closing when a user presses the back button, the event for the camera view is disabled.
+If you still want the user to navigate, you can add a listener for the back event for the preview 
+(see <code>[onBackButtonTapped](#onBackButtonTapped)</code>) 
+
+
+
 # Methods
 
 ### startCamera(options, [successCallback, errorCallback])
@@ -369,6 +377,16 @@ CameraPreview.getSupportedPictureSizes(function(dimensions){
 let xPoint = event.x;
 let yPoint = event.y
 CameraPreview.tapToFocus(xPoint, yPoint);
+```
+
+### onBackButtonTapped(successCallback, [errorCallback])
+
+<info>Callback event for the back button tap</info><br/>
+
+```javascript
+CameraPreview.onBackButtonTapped(function() {
+  console.log('Back button pushed');
+});
 ```
 
 # Settings

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -54,6 +54,7 @@ public class CameraActivity extends Fragment {
     void onPictureTakenError(String message);
     void onFocusSet(int pointX, int pointY);
     void onFocusSetError(String message);
+    void onBackButtonTapped();
     void onCameraStarted();
   }
 
@@ -213,6 +214,20 @@ public class CameraActivity extends Fragment {
                 }
               }
               return true;
+            }
+          });
+          frameContainerLayout.setFocusableInTouchMode(true);
+          frameContainerLayout.requestFocus();
+          frameContainerLayout.setOnKeyListener( new android.view.View.OnKeyListener() {
+            @Override
+            public boolean onKey( android.view.View v, int keyCode, android.view.KeyEvent event ) {
+
+              if( keyCode == android.view.KeyEvent.KEYCODE_BACK )
+              {
+                eventListener.onBackButtonTapped();
+                return true;
+              }
+              return false;
             }
           });
         }

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -54,6 +54,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   private static final String GET_EXPOSURE_COMPENSATION_RANGE_ACTION = "getExposureCompensationRange";
   private static final String GET_WHITE_BALANCE_MODE_ACTION = "getWhiteBalanceMode";
   private static final String SET_WHITE_BALANCE_MODE_ACTION = "setWhiteBalanceMode";
+  private static final String SET_BACK_BUTTON_CALLBACK = "onBackButtonTapped";
 
   private static final int CAM_REQ_CODE = 0;
 
@@ -65,6 +66,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   private CallbackContext takePictureCallbackContext;
   private CallbackContext setFocusCallbackContext;
   private CallbackContext startCameraCallbackContext;
+  private CallbackContext tapBackButtonContext;
 
   private CallbackContext execCallback;
   private JSONArray execArgs;
@@ -142,6 +144,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       return getWhiteBalanceMode(callbackContext);
     } else if (SET_WHITE_BALANCE_MODE_ACTION.equals(action)) {
       return setWhiteBalanceMode(args.getString(0),callbackContext);
+    } else if (SET_BACK_BUTTON_CALLBACK.equals(action)) {
+      return setBackButtonListener(callbackContext);
     }
     return false;
   }
@@ -868,5 +872,16 @@ private boolean getSupportedFocusModes(CallbackContext callbackContext) {
 
     callbackContext.success();
     return true;
+  }
+
+  public boolean setBackButtonListener(CallbackContext callbackContext) {
+    tapBackButtonContext = callbackContext;
+    return true;
+  }
+
+  public void onBackButtonTapped() {
+    Log.d(TAG, "Back button tapped, notifying");
+    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Back button pressed");
+    tapBackButtonContext.sendPluginResult(pluginResult);
   }
 }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -61,4 +61,5 @@ interface CameraPreview {
   getSupportedWhiteBalanceModes(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   getSupportedWhiteBalanceMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   setWhiteBalanceMode(whiteBalanceMode?:CameraPreviewWhiteBalanceMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  onBackButtonTapped(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
 }

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -165,6 +165,10 @@ CameraPreview.setWhiteBalanceMode = function(whiteBalanceMode, onSuccess, onErro
     exec(onSuccess, onError, PLUGIN_NAME, "setWhiteBalanceMode", [whiteBalanceMode]);
 };
 
+CameraPreview.onBackButtonTapped = function(onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "onBackButtonTapped");
+};
+
 CameraPreview.FOCUS_MODE = {
     FIXED: 'fixed',
     AUTO: 'auto',


### PR DESCRIPTION
When using the plugin for older devices, the camera preview will take the focus inside the app once initialized. In order to prevent the app from closing when a user presses the back button, the event for the camera view is disabled. If you still want the user to navigate, you can add a listener for the back event for the preview.

This fixes the issue [#347](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/347)