### PR TITLE
Fixed iOS build - Property 'videoZoomFactor' not found on AVCaptureDeviceFormat

### DIFF
--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -392,7 +392,7 @@
 - (CGFloat)getZoom {
 
   AVCaptureDevice * videoDevice = [self cameraWithPosition: self.defaultCamera];
-  return videoDevice.activeFormat.videoZoomFactor;
+  return videoDevice.videoZoomFactor;
 }
 
 - (float)getHorizontalFOV {


### PR DESCRIPTION
Property 'videoZoomFactor' not found on object of type 'AVCaptureDeviceFormat *'. This PR fixed that.