### PR TITLE
Fix edge case focus

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -575,6 +575,18 @@ public class CameraActivity extends Fragment {
   }
 
   private Rect calculateTapArea(float x, float y, float coefficient) {
+    if (x < 100) {
+      x = 100;
+    }
+    if (x > width - 100) {
+      x = width - 100;
+    }
+    if (y < 100) {
+      y = 100;
+    }
+    if (y > height - 100) {
+      y = height - 100;
+    }
     return new Rect(
       Math.round((x - 100) * 2000 / width  - 1000),
       Math.round((y - 100) * 2000 / height - 1000),


### PR DESCRIPTION
closes #412

setFocusAreas requires by design a value of x or y coordinates in the rect between -1000 to 1000.
https://developer.android.com/reference/android/hardware/Camera.Parameters.html#getFocusAreas()

Previously it was possible to achieve values which did not comply with the specs which did crash the focus action.