### PR TITLE
Android: allow images to not be automatically rotated

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ All options stated are optional and will default to values here
 * `tapPhoto` - Defaults to true - Does not work if toBack is set to false in which case you use the takePicture method
 * `tapFocus` - Defaults to false - Allows the user to tap to focus, when the view is in the foreground
 * `previewDrag` - Defaults to false - Does not work if toBack is set to false
+* `disableExifHeaderStripping` - Defaults to false - On Android disable automatic rotation of the image, and let the browser deal with it (keep reading on how to achieve it)
 
 ```javascript
 let options = {
@@ -118,6 +119,78 @@ html, body, .ion-app, .ion-content {
 ```
 
 When both tapFocus and tapPhoto are true, the camera will focus, and take a picture as soon as the camera is done focusing.
+
+#### Using disableExifHeaderStripping
+
+If you want to capture large images you will notice in Android that performace is very bad, in those cases you can set
+this flag, and add some extra Javascript/HTML to get a proper display of your captured images without risking your application speed.
+
+Example:
+
+```html
+<script src="https://raw.githubusercontent.com/blueimp/JavaScript-Load-Image/master/js/load-image.all.min.js"></script>
+
+<p><div id="originalPicture" style="width: 100%"></div></p>
+```
+
+```javascript
+let options = {
+  x: 0,
+  y: 0,
+  width: window.screen.width,
+  height: window.screen.height,
+  camera: CameraPreview.CAMERA_DIRECTION.BACK,
+  toBack: false,
+  tapPhoto: true,
+  tapFocus: false,
+  previewDrag: false,
+  disableExifHeaderStripping: true
+};
+....
+
+function gotRotatedCanvas(canvasimg) {
+  var displayCanvas = $('canvas#display-canvas');
+  loadImage.scale(canvasimg, function(img){
+    displayCanvas.drawImage(img)
+  }, {
+    maxWidth: displayCanvas.width,
+    maxHeight: displayCanvas.height
+  });
+}
+
+CameraPreview.getSupportedPictureSizes(function(dimensions){
+  dimensions.sort(function(a, b){
+    return (b.width * b.height - a.width * a.height);
+  });
+  var dimension = dimensions[0];
+  CameraPreview.takePicture({width:dimension.width, height:dimension.height, quality: 85}, function(base64PictureData){
+    /*
+      base64PictureData is base64 encoded jpeg image. Use this data to store to a file or upload.
+      Its up to the you to figure out the best way to save it to disk or whatever for your application.
+    */
+
+    var image = 'data:image/jpeg;base64,' + imgData;
+    let holder = document.getElementById('originalPicture');
+    let width = holder.offsetWidth;
+    loadImage(
+      image,
+      function(canvas) {
+        holder.innerHTML = "";
+        if (app.camera === 'front') {
+          // front camera requires we flip horizontally
+          canvas.style.transform = 'scale(1, -1)';
+        }
+        holder.appendChild(canvas);
+      },
+      {
+        maxWidth: width,
+        orientation: true,
+        canvas: true
+      }
+    );
+  });
+});
+```
 
 ### stopCamera([successCallback, errorCallback])
 

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -79,6 +79,7 @@ public class CameraActivity extends Fragment {
   public boolean tapToTakePicture;
   public boolean dragEnabled;
   public boolean tapToFocus;
+  public boolean disableExifHeaderStripping;
 
   public int width;
   public int height;
@@ -400,27 +401,29 @@ public class CameraActivity extends Fragment {
       Log.d(TAG, "CameraPreview jpegPictureCallback");
 
       try {
-        Matrix matrix = new Matrix();
-        if (cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-          matrix.preScale(1.0f, -1.0f);
-        }
+        if (!disableExifHeaderStripping) {
+          Matrix matrix = new Matrix();
+          if (cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+            matrix.preScale(1.0f, -1.0f);
+          }
 
-        ExifInterface exifInterface = new ExifInterface(new ByteArrayInputStream(data));
-        int rotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
-        int rotationInDegrees = exifToDegrees(rotation);
+          ExifInterface exifInterface = new ExifInterface(new ByteArrayInputStream(data));
+          int rotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+          int rotationInDegrees = exifToDegrees(rotation);
 
-        if (rotation != 0f) {
-          matrix.preRotate(rotationInDegrees);
-        }
+          if (rotation != 0f) {
+            matrix.preRotate(rotationInDegrees);
+          }
 
-        // Check if matrix has changed. In that case, apply matrix and override data
-        if (!matrix.isIdentity()) {
-          Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length);
-          bitmap = applyMatrix(bitmap, matrix);
+          // Check if matrix has changed. In that case, apply matrix and override data
+          if (!matrix.isIdentity()) {
+            Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length);
+            bitmap = applyMatrix(bitmap, matrix);
 
-          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-          bitmap.compress(Bitmap.CompressFormat.JPEG, currentQuality, outputStream);
-          data = outputStream.toByteArray();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            bitmap.compress(Bitmap.CompressFormat.JPEG, currentQuality, outputStream);
+            data = outputStream.toByteArray();
+          }
         }
 
         String encodedImage = Base64.encodeToString(data, Base64.NO_WRAP);

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -86,7 +86,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
     if (START_CAMERA_ACTION.equals(action)) {
       if (cordova.hasPermission(permissions[0])) {
-        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), args.getBoolean(9), callbackContext);
+        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), args.getBoolean(9), args.getBoolean(10), callbackContext);
       } else {
         this.execCallback = callbackContext;
         this.execArgs = args;
@@ -165,7 +165,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       }
     }
     if (requestCode == CAM_REQ_CODE) {
-      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execArgs.getBoolean(9), this.execCallback);
+      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execArgs.getBoolean(9), this.execArgs.getBoolean(10), this.execCallback);
     }
   }
 
@@ -222,7 +222,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, CallbackContext callbackContext) {
+    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, boolean disableExifHeaderStripping, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
     if (fragment != null) {
       callbackContext.error("Camera already started");
@@ -237,6 +237,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     fragment.tapToTakePicture = tapToTakePicture;
     fragment.dragEnabled = dragEnabled;
     fragment.tapToFocus = tapFocus;
+    fragment.disableExifHeaderStripping = disableExifHeaderStripping;
 
     DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
     // offset

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -33,6 +33,7 @@
     BOOL toBack = (BOOL)[command.arguments[7] boolValue];
     CGFloat alpha = (CGFloat)[command.arguments[8] floatValue];
     BOOL tapToFocus = (BOOL) [command.arguments[9] boolValue];
+    BOOL disableExifHeaderStripping = (BOOL) [command.arguments[10] boolValue]; // ignore Android only
 
     // Create the session manager
     self.sessionManager = [[CameraSessionManager alloc] init];

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -19,6 +19,7 @@ interface CameraPreviewStartCameraOptions {
   width?: number;
   x?: number;
   y?: number;
+  disableExifHeaderStripping?: boolean;
 }
 
 interface CameraPreviewTakePictureOptions {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -30,8 +30,8 @@ CameraPreview.startCamera = function(options, onSuccess, onError) {
     if (typeof(options.alpha) === 'undefined') {
         options.alpha = 1;
     }
-
-    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha, options.tapFocus]);
+    options.disableExifHeaderStripping = options.disableExifHeaderStripping || false;
+    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha, options.tapFocus, options.disableExifHeaderStripping]);
 };
 
 CameraPreview.stopCamera = function(onSuccess, onError) {


### PR DESCRIPTION
Introducing disableExifHeaderStripping which disables the automatic rotation of images based on EXIF header, and just keeps this header around so images can be rotated on a display canvas and not while
encoding to avoid time expensive operations on Java level.

This PR goes along with: https://github.com/manuelnaranjo/cordova-plugin-camera-preview-sample-app/commit/5f378953b90dca0434c5513e2721d870bdf01ec7 which I will create a PR once this gets merged