### PR TITLE
Android: fix height and width being ignored in take picture

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -463,6 +463,8 @@ public class CameraActivity extends Fragment {
       size.width = size.height;
       size.height = temp;
     }
+    
+    Camera.Size requestedSize = mCamera.new Size(size.width, size.height);
 
     double previewAspectRatio  = (double)previewSize.width / (double)previewSize.height;
 
@@ -480,7 +482,7 @@ public class CameraActivity extends Fragment {
       Camera.Size supportedSize = supportedSizes.get(i);
 
       // Perfect match
-      if (supportedSize.equals(size)) {
+      if (supportedSize.equals(requestedSize)) {
         Log.d(TAG, "CameraPreview optimalPictureSize " + supportedSize.width + 'x' + supportedSize.height);
         return supportedSize;
       }


### PR DESCRIPTION
Keep a copy of the original size object for checking 'best match' on subsequent loop iterations.