### PR TITLE
Allow to store directly into a temporary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,38 @@ CameraPreview.getSupportedPictureSizes(function(dimensions){
   });
 });
 ```
+### getBlob(url, [successCallback, errorCallback])
 
+When working with local files you may want to display those on certain containers like canvas,
+given that file:// is not always a valid url type, you need to first convert it explicitly to
+a blob, before you push it further into the display side. The function getBlob will do the
+proper conversion for you, and if succedeed will pass the content on it's callback function as
+first argument.
+
+```javascript
+
+function displayImage(content) {
+  var ctx = $("canvas").getContext('2d');
+
+  img.onload = function(){
+    ctx.drawImage(img, 0, 0)
+  }
+
+  img.src = URL.createObjectURL(blob);
+}
+
+function takePicture() {
+  CameraPreview.takePicture({width: app.dimension.width, height: app.dimension.height}, function(data){
+    if (cordova.platformId === 'android') {
+      CameraPreview.getBlob('file://' + data, function(image) {
+        displayImage(image);
+      });
+    } else {
+      displayImage('data:image/jpeg;base64,' + data);
+    }
+  });
+}
+```
 
 ### stopCamera([successCallback, errorCallback])
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -86,7 +86,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
     if (START_CAMERA_ACTION.equals(action)) {
       if (cordova.hasPermission(permissions[0])) {
-        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), args.getBoolean(9), args.getBoolean(10), callbackContext);
+        return startCamera(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), args.getString(4), args.getBoolean(5), args.getBoolean(6), args.getBoolean(7), args.getString(8), args.getBoolean(9), args.getBoolean(10), args.getBoolean(11), callbackContext);
       } else {
         this.execCallback = callbackContext;
         this.execArgs = args;
@@ -165,7 +165,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       }
     }
     if (requestCode == CAM_REQ_CODE) {
-      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execArgs.getBoolean(9), this.execArgs.getBoolean(10), this.execCallback);
+      startCamera(this.execArgs.getInt(0), this.execArgs.getInt(1), this.execArgs.getInt(2), this.execArgs.getInt(3), this.execArgs.getString(4), this.execArgs.getBoolean(5), this.execArgs.getBoolean(6), this.execArgs.getBoolean(7), this.execArgs.getString(8), this.execArgs.getBoolean(9), this.execArgs.getBoolean(10), this.execArgs.getBoolean(11), this.execCallback);
     }
   }
 
@@ -222,7 +222,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, boolean disableExifHeaderStripping, CallbackContext callbackContext) {
+    private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, boolean disableExifHeaderStripping, boolean storeToFile, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
     if (fragment != null) {
       callbackContext.error("Camera already started");
@@ -238,6 +238,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     fragment.dragEnabled = dragEnabled;
     fragment.tapToFocus = tapFocus;
     fragment.disableExifHeaderStripping = disableExifHeaderStripping;
+    fragment.storeToFile = storeToFile;
 
     DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
     // offset

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -34,6 +34,7 @@
     CGFloat alpha = (CGFloat)[command.arguments[8] floatValue];
     BOOL tapToFocus = (BOOL) [command.arguments[9] boolValue];
     BOOL disableExifHeaderStripping = (BOOL) [command.arguments[10] boolValue]; // ignore Android only
+    BOOL storeToFile = (BOOL) [command.arguments[11] boolValue]; // ignore Android only
 
     // Create the session manager
     self.sessionManager = [[CameraSessionManager alloc] init];

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -66,5 +66,5 @@ interface CameraPreview {
   getSupportedWhiteBalanceMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   setWhiteBalanceMode(whiteBalanceMode?:CameraPreviewWhiteBalanceMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   onBackButton(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
-  fetchLocal(path: string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+  getBlob(path: string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
 }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -20,6 +20,7 @@ interface CameraPreviewStartCameraOptions {
   x?: number;
   y?: number;
   disableExifHeaderStripping?: boolean;
+  storeToFile?: boolean;
 }
 
 interface CameraPreviewTakePictureOptions {
@@ -65,4 +66,5 @@ interface CameraPreview {
   getSupportedWhiteBalanceMode(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   setWhiteBalanceMode(whiteBalanceMode?:CameraPreviewWhiteBalanceMode|string, onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
   onBackButton(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
+  fetchLocal(path: string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
 }

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -31,7 +31,8 @@ CameraPreview.startCamera = function(options, onSuccess, onError) {
         options.alpha = 1;
     }
     options.disableExifHeaderStripping = options.disableExifHeaderStripping || false;
-    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha, options.tapFocus, options.disableExifHeaderStripping]);
+    options.storeToFile = options.storeToFile || false;
+    exec(onSuccess, onError, PLUGIN_NAME, "startCamera", [options.x, options.y, options.width, options.height, options.camera, options.tapPhoto, options.previewDrag, options.toBack, options.alpha, options.tapFocus, options.disableExifHeaderStripping, options.storeToFile]);
 };
 
 CameraPreview.stopCamera = function(onSuccess, onError) {
@@ -175,6 +176,30 @@ CameraPreview.setWhiteBalanceMode = function(whiteBalanceMode, onSuccess, onErro
 
 CameraPreview.onBackButton = function(onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "onBackButton");
+};
+
+CameraPreview.fetchLocal = function(url, onSuccess, onError) {
+    var xhr = new XMLHttpRequest
+    xhr.onload = function() {
+        if (xhr.status != 0 && (xhr.status < 200 || xhr.status >= 300)) {
+            if (isFunction(onError)) {
+                onError('Local request failed');
+            }
+            return;
+        }
+        var blob = new Blob([xhr.response], {type: "image/jpeg"});
+        if (isFunction(onSuccess)) {
+            onSuccess(blob);
+        }
+    };
+    xhr.onerror = function() {
+        if (isFunction(onError)) {
+            onError('Local request failed');
+        }
+    };
+    xhr.open('GET', url);
+    xhr.responseType = 'arraybuffer';
+    xhr.send(null);
 };
 
 CameraPreview.FOCUS_MODE = {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -178,7 +178,7 @@ CameraPreview.onBackButton = function(onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "onBackButton");
 };
 
-CameraPreview.fetchLocal = function(url, onSuccess, onError) {
+CameraPreview.getBlob = function(url, onSuccess, onError) {
     var xhr = new XMLHttpRequest
     xhr.onload = function() {
         if (xhr.status != 0 && (xhr.status < 200 || xhr.status >= 300)) {


### PR DESCRIPTION
On Android we now allow to on-demand store into a temporary file. There's a chance for a race condition, which I'm not going to take into account, which is the case where multiple images are been taken and the file is not been read on time. But it's a trade-off we need to accept.

Documentation has been updated, also reflecting the fact that only 1 image is possible to take at the time.

No extra permissions are required as image is stored inside the app cache.
