### PR TITLE
Updated to work when permissions not yet granted

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -91,6 +91,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
         this.execCallback = callbackContext;
         this.execArgs = args;
         cordova.requestPermissions(this, CAM_REQ_CODE, permissions);
+        return true;
       }
     } else if (TAKE_PICTURE_ACTION.equals(action)) {
       return takePicture(args.getInt(0), args.getInt(1), args.getInt(2), callbackContext);


### PR DESCRIPTION
Updated execute call to return true, even if permissions are not yet granted so that Cordova does not throw an 'Invalid action' response.