### PR TITLE
481 storetofile for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ All options stated are optional and will default to values here
 * `tapPhoto` - Defaults to true - Does not work if toBack is set to false in which case you use the takePicture method
 * `tapFocus` - Defaults to false - Allows the user to tap to focus, when the view is in the foreground
 * `previewDrag` - Defaults to false - Does not work if toBack is set to false
+* `storeToFile` - Defaults to false - Capture images to a file and return back the file path instead of returning base64 encoded data.
 * `disableExifHeaderStripping` - Defaults to false - **Android Only** - Disable automatic rotation of the image, and let the browser deal with it (keep reading on how to achieve it)
-* `storeToFile` - Defaults to false - **Android Only** - Capture images to a file and return back the file path instead of returning base64 encoded data.
 
 ```javascript
 let options = {
@@ -106,7 +106,9 @@ let options = {
   toBack: false,
   tapPhoto: true,
   tapFocus: false,
-  previewDrag: false
+  previewDrag: false,
+  storeToFile: false,
+  disableExifHeaderStripping: false
 };
 
 CameraPreview.startCamera(options);
@@ -159,14 +161,21 @@ CameraPreview.hide();
 <info>Take the picture. If width and height are not specified or are 0 it will use the defaults. If width and height are specified, it will choose a supported photo size that is closest to width and height specified and has closest aspect ratio to the preview. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/>
 
 ```javascript
-CameraPreview.takePicture({width:640, height:640, quality: 85}, function(base64PictureData){
+CameraPreview.takePicture({width:640, height:640, quality: 85}, function(base64PictureData|filePath) {
   /*
+    if the storeToFile option is false (the default), then base64PictureData is returned.
     base64PictureData is base64 encoded jpeg image. Use this data to store to a file or upload.
     Its up to the you to figure out the best way to save it to disk or whatever for your application.
   */
 
+  /*
+    if the storeToFile option is set to true, then a filePath is returned. Note that the file
+    is stored in temporary storage, so you should move it to a permanent location if you
+    don't want the OS to remove it arbitrarily.
+  */
+
   // One simple example is if you are going to use it inside an HTML img src attribute then you would do the following:
-  imageSrcData = 'data:image/jpeg;base64,' +base64PictureData;
+  imageSrcData = 'data:image/jpeg;base64,' + base64PictureData;
   $('img#my-img').attr('src', imageSrcData);
 });
 
@@ -499,14 +508,11 @@ function takePicture() {
 
 # storeToFile
 
-When capturing large images you rather want those to be stored into a file instead of having those
+When capturing large images you may want them to be stored into a file instead of having them
 base64 enconded, as enconding at least on Android is very expensive. With the feature storeToFile enabled
 the plugin will capture the image into a temporary file inside the application temporary cache (the same
-place where Cordova will extract your assets). *NOTE:* this method will overwrite any previous captured
-image for sake of simplicity, so if you want to capture multiple images and keep those, you will need
-assistance from some other plugin to rename the file or store somewhere else, this is made by design to
-keep the plugin simple. This method is better used with *disableExifHeaderStripping* to get the best
-possible performance.
+place where Cordova will extract your assets). This method is better used with *disableExifHeaderStripping* 
+to get the best possible performance.
 
 
 Example:
@@ -743,14 +749,14 @@ Note: Use AUTO to allow the device automatically adjusts the exposure once and t
 It is not possible to use your computers webcam during testing in the simulator, you must device test.
 
 # Customize Android Support Library versions (Android only)
-The default `ANDROID_SUPPORT_LIBRARY_VERSION` is set to `25+`.
+The default `ANDROID_SUPPORT_LIBRARY_VERSION` is set to `26+`.
 If you need a different version, add argument `--variable ANDROID_SUPPORT_LIBRARY_VERSION="{version}"`.
 
 Or edit `config.xml` with following,
 
 ```xml
 <plugin name="cordova-plugin-camera-preview" spec="X.X.X">
-  <variable name="ANDROID_SUPPORT_LIBRARY_VERSION" value="25+" />
+  <variable name="ANDROID_SUPPORT_LIBRARY_VERSION" value="26+" />
 </plugin>
 ```
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,7 @@
     <source-file src="src/android/camera_theme.xml" target-dir="res/values" />
     <source-file src="src/android/camera_ids.xml" target-dir="res/values" />
 
-    <preference name="ANDROID_SUPPORT_LIBRARY_VERSION" default="25+"/>
+    <preference name="ANDROID_SUPPORT_LIBRARY_VERSION" default="26+"/>
     <framework src="com.android.support:exifinterface:$ANDROID_SUPPORT_LIBRARY_VERSION" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -48,6 +48,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Arrays;
+import java.util.UUID;
 
 public class CameraActivity extends Fragment {
 
@@ -417,6 +418,10 @@ public class CameraActivity extends Fragment {
     return cache.getAbsolutePath();
 }
 
+private String getTempFilePath() {
+  return getTempDirectoryPath() + "/capture_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8) + ".jpg"
+}
+
   PictureCallback jpegPictureCallback = new PictureCallback(){
     public void onPictureTaken(byte[] data, Camera arg1){
       Log.d(TAG, "CameraPreview jpegPictureCallback");
@@ -452,7 +457,7 @@ public class CameraActivity extends Fragment {
 
           eventListener.onPictureTaken(encodedImage);
         } else {
-          String path = getTempDirectoryPath() + "/capture.jpg";
+          String path = getTempFilePath();
           FileOutputStream out = new FileOutputStream(path);
           out.write(data);
           out.close();

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -416,11 +416,11 @@ public class CameraActivity extends Fragment {
     // Create the cache directory if it doesn't exist
     cache.mkdirs();
     return cache.getAbsolutePath();
-}
+  }
 
-private String getTempFilePath() {
-  return getTempDirectoryPath() + "/capture_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8) + ".jpg"
-}
+  private String getTempFilePath() {
+    return getTempDirectoryPath() + "/cpcp_capture_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8) + ".jpg";
+  }
 
   PictureCallback jpegPictureCallback = new PictureCallback(){
     public void onPictureTaken(byte[] data, Camera arg1){

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -45,5 +45,6 @@
 @property (nonatomic) CameraSessionManager *sessionManager;
 @property (nonatomic) CameraRenderController *cameraRenderController;
 @property (nonatomic) NSString *onPictureTakenHandlerId;
+@property (nonatomic) BOOL storeToFile;
 
 @end

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -4,6 +4,8 @@
 
 #import "CameraPreview.h"
 
+#define TMP_IMAGE_PREFIX @"cpcp_capture_"
+
 @implementation CameraPreview
 
 -(void) pluginInitialize{
@@ -34,7 +36,7 @@
     CGFloat alpha = (CGFloat)[command.arguments[8] floatValue];
     BOOL tapToFocus = (BOOL) [command.arguments[9] boolValue];
     BOOL disableExifHeaderStripping = (BOOL) [command.arguments[10] boolValue]; // ignore Android only
-    BOOL storeToFile = (BOOL) [command.arguments[11] boolValue]; // ignore Android only
+    self.storeToFile = (BOOL) [command.arguments[11] boolValue];
 
     // Create the session manager
     self.sessionManager = [[CameraSessionManager alloc] init];
@@ -80,36 +82,23 @@
 }
 
 - (void) stopCamera:(CDVInvokedUrlCommand*)command {
-    
     NSLog(@"stopCamera");
+    CDVPluginResult *pluginResult;
     
-    [self.cameraRenderController.view removeFromSuperview];
-    [self.cameraRenderController removeFromParentViewController];
-    self.cameraRenderController = nil;
+    if(self.sessionManager != nil) {
+        [self.cameraRenderController.view removeFromSuperview];
+        [self.cameraRenderController removeFromParentViewController];
+        
+        self.cameraRenderController = nil;
+        self.sessionManager = nil;
+        
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+    }
     
-    [self.commandDelegate runInBackground:^{
-        
-        CDVPluginResult *pluginResult;
-        if(self.sessionManager != nil) {
-            
-            for(AVCaptureInput *input in self.sessionManager.session.inputs) {
-                [self.sessionManager.session removeInput:input];
-            }
-            
-            for(AVCaptureOutput *output in self.sessionManager.session.outputs) {
-                [self.sessionManager.session removeOutput:output];
-            }
-            
-            [self.sessionManager.session stopRunning];
-            self.sessionManager = nil;
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        }
-        else {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-        }
-        
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) hideCamera:(CDVInvokedUrlCommand*)command {
@@ -678,6 +667,7 @@
       if (error) {
         NSLog(@"%@", error);
       } else {
+
         NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:sampleBuffer];
         UIImage *capturedImage  = [[UIImage alloc] initWithData:imageData];
 
@@ -719,8 +709,6 @@
           finalCImage = imageToFilter;
         }
 
-        NSMutableArray *params = [[NSMutableArray alloc] init];
-
         CGImageRef finalImage = [self.cameraRenderController.ciContext createCGImage:finalCImage fromRect:finalCImage.extent];
         UIImage *resultImage = [UIImage imageWithCGImage:finalImage];
 
@@ -729,16 +717,52 @@
 
         CGImageRelease(finalImage); // release CGImageRef to remove memory leaks
 
-        NSString *base64Image = [self getBase64Image:resultFinalImage withQuality:quality];
+        CDVPluginResult *pluginResult;
+        if (self.storeToFile) {
+          NSData *data = UIImageJPEGRepresentation([UIImage imageWithCGImage:resultFinalImage], (CGFloat) quality);
+          NSString* filePath = [self getTempFilePath:@"jpg"];
+          NSError *err;
+         
+          if (![data writeToFile:filePath options:NSAtomicWrite error:&err]) {           
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[err localizedDescription]];
+          }
+          else {           
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSURL fileURLWithPath:filePath] absoluteString]];
+          }
+        } else {
+          NSMutableArray *params = [[NSMutableArray alloc] init];
+          NSString *base64Image = [self getBase64Image:resultFinalImage withQuality:quality];
+          [params addObject:base64Image];
+          pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
+        }
 
         CGImageRelease(resultFinalImage); // release CGImageRef to remove memory leaks
 
-        [params addObject:base64Image];
-
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
         [pluginResult setKeepCallbackAsBool:true];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.onPictureTakenHandlerId];
       }
     }];
 }
+
+- (NSString*)getTempDirectoryPath
+{
+  NSString* tmpPath = [NSTemporaryDirectory()stringByStandardizingPath];
+  return tmpPath;
+}
+
+- (NSString*)getTempFilePath:(NSString*)extension
+{
+    NSString* tmpPath = [self getTempDirectoryPath];
+    NSFileManager* fileMgr = [[NSFileManager alloc] init]; // recommended by Apple (vs [NSFileManager defaultManager]) to be threadsafe
+    NSString* filePath;
+
+    // generate unique file name
+    int i = 1;
+    do {
+        filePath = [NSString stringWithFormat:@"%@/%@%04d.%@", tmpPath, TMP_IMAGE_PREFIX, i++, extension];
+    } while ([fileMgr fileExistsAtPath:filePath]);
+    
+    return filePath;
+}
+
 @end


### PR DESCRIPTION
Hi @westonganger, I finally got around to adding iOS support for the storeToFile option, which we discussed here: https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/481. Can you merge this pull request?

Aside from adding support for storeToFile on iOS, it also changes the temporary file name generated for Android, to avoid overwriting an existing capture. Now, a randomly generated file name is created. @Et3rnal, this may solve the issue you raised in #489. 

I would like the iOS version of getTempFilePath() to behave identically to the Android version, but I'm not an experienced Objective C developer. The storeToFile support for iOS could probably also be implemented in a cleaner manner.

Much of the code I used was borrowed from https://github.com/hobbydevs/cordova-plugin-camera-preview.

