### PR TITLE
mCamera is never set to null

### DIFF
--- a/src/android/Preview.java
+++ b/src/android/Preview.java
@@ -48,9 +48,10 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback {
   }
 
   public void setCamera(Camera camera, int cameraId) {
+    mCamera = camera;
+    this.cameraId = cameraId;
+
     if (camera != null) {
-      mCamera = camera;
-      this.cameraId = cameraId;
       mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
       setCameraDisplayOrientation();
 


### PR DESCRIPTION
This causes crash of the whole app when you try to use a different plugin using camera e.g. BarcodeScanner after using CameraPreview.