### PR TITLE
Potential fix for the issue when the app crashes/restarts web view due to OOM, when capturing multiple photos

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -366,7 +366,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Log.d(TAG, "Camera started");
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Camera started");
-    pluginResult.setKeepCallback(true);
+    pluginResult.setKeepCallback(false);
     startCameraCallbackContext.sendPluginResult(pluginResult);
   }
 
@@ -417,7 +417,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     data.put(originalPicture);
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, data);
-    pluginResult.setKeepCallback(true);
+    pluginResult.setKeepCallback(fragment.tapToTakePicture);
     takePictureCallbackContext.sendPluginResult(pluginResult);
   }
 

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -759,7 +759,7 @@
 
         CGImageRelease(resultFinalImage); // release CGImageRef to remove memory leaks
 
-        [pluginResult setKeepCallbackAsBool:true];
+        [pluginResult setKeepCallbackAsBool:self.cameraRenderController.tapToTakePicture];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.onPictureTakenHandlerId];
       }
     }];


### PR DESCRIPTION
For more details please see https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/604

This also changed to remove cordova callback for cameraStart method invocation.