### PR TITLE
Fix AndroidManifest.xml conflict with other camera plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,8 +33,8 @@
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-feature android:name="android.hardware.camera" android:required="true"/>
-      <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
+      <uses-feature android:name="android.hardware.camera"/>
+      <uses-feature android:name="android.hardware.camera.autofocus"/>
       <uses-permission android:name="android.permission.CAMERA" />
       <uses-permission android:name="android.permission.RECORD_AUDIO" />
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
When installing 2 or more camera plugins, the tags merge in the manifest file, but when the tags are distinct, like this that have the `android:required="true"` attribute, the Android manifest ends with something like this:

```
<uses-feature android:name="android.hardware.camera" android:required="true" />
<uses-feature android:name="android.hardware.camera" android:required="false" />
<uses-feature android:name="android.hardware.camera" />
```

and this error appears:
"**Element uses-permission#android.permission.CAMERA at AndroidManifest.xml:59:5-65 duplicated with element declared at AndroidManifest.xml**"

this "andoid:required" attribute is just used for the PlayStore to know if the device is compatible, But of course, there is almost none android phones without camera so this is doing nothing here.
