### PR TITLE
[CameraPreview.m] Correctly handle torch mode in getFlashMode

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -205,16 +205,21 @@
   CDVPluginResult *pluginResult;
 
   if (self.sessionManager != nil) {
+    BOOL isTorchActive = [self.sessionManager isTorchActive];
     NSInteger flashMode = [self.sessionManager getFlashMode];
     NSString * sFlashMode;
-    if (flashMode == 0) {
-      sFlashMode = @"off";
-    } else if (flashMode == 1) {
-      sFlashMode = @"on";
-    } else if (flashMode == 2) {
-      sFlashMode = @"auto";
+    if (isTorchActive) {
+      sFlashMode = @"torch";
     } else {
-      sFlashMode = @"unsupported";
+      if (flashMode == 0) {
+        sFlashMode = @"off";
+      } else if (flashMode == 1) {
+        sFlashMode = @"on";
+      } else if (flashMode == 2) {
+        sFlashMode = @"auto";
+      } else {
+        sFlashMode = @"unsupported";
+      }
     }
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:sFlashMode ];
   } else {

--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -34,6 +34,7 @@
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (void) tapToFocus:(CGFloat)xPoint yPoint:(CGFloat)yPoint;
 - (void) takePictureOnFocus;
+- (BOOL) isTorchActive;
 - (void) setTorchMode;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -353,6 +353,10 @@
   }
 }
 
+- (BOOL)isTorchActive {
+  return ([self.device hasTorch] && [self.device isTorchAvailable] && [self.device isTorchActive]);
+}
+
 - (void)setTorchMode {
   NSError *error = nil;
 


### PR DESCRIPTION
`getFlashMode` was not handling the torch mode on iOS.
While it was possible to set the torch mode via `setFlashMode`, `getFlashMode` returned the previous flash mode if torch mode was currently set.
This fixes the issue by checking for active torch and returning `torch` as flash mode in this case.