### PR TITLE
[Feature] setPreviewDimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,14 @@ CameraPreview.setExposureCompensation(3);
 CameraPreview.setPreviewSize({width: window.screen.width, height: window.screen.height});
 ```
 
+### setPreviewDimensions([dimensions, successCallback, errorCallback])
+
+<info>Change the position and size of the preview window.</info><br/>
+
+```javascript
+CameraPreview.setPreviewDimensions({x: 0, y: 0, width: window.screen.width, height: window.screen.height});
+```
+
 ### getSupportedPictureSizes(cb, [errorCallback])
 
 ```javascript

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -49,6 +49,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   private static final String START_CAMERA_ACTION = "startCamera";
   private static final String STOP_CAMERA_ACTION = "stopCamera";
   private static final String PREVIEW_SIZE_ACTION = "setPreviewSize";
+  private static final String PREVIEW_DIMENSIONS_ACTION = "setPreviewDimensions";
   private static final String SWITCH_CAMERA_ACTION = "switchCamera";
   private static final String TAKE_PICTURE_ACTION = "takePicture";
   private static final String START_RECORD_VIDEO_ACTION = "startRecordVideo";
@@ -146,6 +147,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       return getMaxZoom(callbackContext);
     } else if (PREVIEW_SIZE_ACTION.equals(action)) {
       return setPreviewSize(args.getInt(0), args.getInt(1), callbackContext);
+    } else if (PREVIEW_DIMENSIONS_ACTION.equals(action)) {
+      return setPreviewDimensions(args.getInt(0), args.getInt(1), args.getInt(2), args.getInt(3), callbackContext);
     } else if (SUPPORTED_FLASH_MODES_ACTION.equals(action)) {
       return getSupportedFlashModes(callbackContext);
     } else if (GET_FLASH_MODE_ACTION.equals(action)) {
@@ -852,6 +855,22 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Camera.Parameters params = camera.getParameters();
 
     params.setPreviewSize(width, height);
+    fragment.setCameraParameters(params);
+    camera.startPreview();
+
+    callbackContext.success();
+    return true;
+  }
+
+  private boolean setPreviewDimensions(int x, int y, int width, int height, CallbackContext callbackContext) {
+    if(this.hasCamera(callbackContext) == false){
+      return true;
+    }
+
+    Camera camera = fragment.getCamera();
+    Camera.Parameters params = camera.getParameters();
+
+    params.setPreviewDimensions(width, height);
     fragment.setCameraParameters(params);
     camera.startPreview();
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -870,7 +870,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Camera camera = fragment.getCamera();
     Camera.Parameters params = camera.getParameters();
 
-    params.setPreviewDimensions(width, height);
+    params.setPreviewSize(width, height);
     fragment.setCameraParameters(params);
     camera.startPreview();
 

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -26,6 +26,7 @@
 - (void) setExposureCompensation:(CDVInvokedUrlCommand*)command;
 - (void) getExposureCompensationRange:(CDVInvokedUrlCommand*)command;
 - (void) setPreviewSize: (CDVInvokedUrlCommand*)command;
+- (void) setPreviewDimensions: (CDVInvokedUrlCommand*)command;
 - (void) switchCamera:(CDVInvokedUrlCommand*)command;
 - (void) takePicture:(CDVInvokedUrlCommand*)command;
 - (void) takeSnapshot:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -549,6 +549,32 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) setPreviewDimensions: (CDVInvokedUrlCommand*)command {
+
+    CDVPluginResult *pluginResult;
+
+    if (self.sessionManager == nil) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Session not started"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+
+    if (command.arguments.count > 3) {
+        CGFloat x = (CGFloat)[command.arguments[0] floatValue] + self.webView.frame.origin.x;
+        CGFloat y = (CGFloat)[command.arguments[1] floatValue] + self.webView.frame.origin.y;
+        CGFloat width = (CGFloat)[command.arguments[2] floatValue];
+        CGFloat height = (CGFloat)[command.arguments[3] floatValue];
+
+        self.cameraRenderController.view.frame = CGRectMake(x, y, width, height);
+
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid number of parameters"];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) getSupportedPictureSizes:(CDVInvokedUrlCommand*)command {
   NSLog(@"getSupportedPictureSizes");
   CDVPluginResult *pluginResult;

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -35,6 +35,8 @@ declare module 'cordova-plugin-camera-preview' {
   }
 
   interface CameraPreviewPreviewSizeDimension {
+    x?: number;
+    y?: number;
     height?: number;
     width?: number;
   }
@@ -56,6 +58,7 @@ declare module 'cordova-plugin-camera-preview' {
     getZoom(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getHorizontalFOV(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     setPreviewSize(dimensions?: CameraPreviewPreviewSizeDimension|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setPreviewDimensions(dimensions?: CameraPreviewPreviewSizeDimension|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedPictureSizes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedFlashModes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedColorEffects(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -147,6 +147,16 @@ CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
 };
 
+CameraPreview.setPreviewDimensions = function(dimensions, onSuccess, onError) {
+  dimensions = dimensions || {};
+  dimensions.x = dimensions.x || 0;
+  dimensions.y = dimensions.y || 0;
+  dimensions.width = dimensions.width || window.screen.width;
+  dimensions.height = dimensions.height || window.screen.height;
+
+  exec(onSuccess, onError, PLUGIN_NAME, "setPreviewDimensions", [dimensions.x, dimensions.y, dimensions.width, dimensions.height]);
+};
+
 CameraPreview.getSupportedPictureSizes = function(onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
 };


### PR DESCRIPTION
**_In development!_ (need help for Android)**

This feature is for deprecating the `setPreviewSize`-method which just can set the size (`width` and `height`) on the camera preview. `setPreviewDimensions` is for setting also the position (`x` and `y`) of the camera preview.

With this we can relocate and change the size of the preview window without having to restart the camera preview at all. So orientation changes can be done with no hassle also.

**_Need help for Android:_**

- In Android there is the problem that right now on orientation changes the camera preview does not change the orientation like the screen. This can be fixed with `Preview.setCameraDisplayOrientation()` or `Preview.setCamera(Camera camera, int cameraId)` on the right place. This has to be considered to be fixed the right way for android.

- The size of the camera preview could be changed with `Camera.Parameters.setPreviewSize(int width, int height)` like the `setPreviewSize`-method does.

- Problem is for me right now how to set the position. If you can give me a clue that would be nice.

If you have a look in the iOS implementation you can see that it is really easy and everything works really fine.