### PR TITLE
Make android camera hardware nonrequired in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,8 +33,8 @@
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-feature android:name="android.hardware.camera"/>
-      <uses-feature android:name="android.hardware.camera.autofocus"/>
+      <uses-feature android:name="android.hardware.camera" android:required="false"/>
+      <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
       <uses-permission android:name="android.permission.CAMERA" />
       <uses-permission android:name="android.permission.RECORD_AUDIO" />
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
The plugin reduces device support by requiring the following features:
- `android.hardware.camera`
- `android.hardware.camera.autofocus`

Google Play filters apps that use this plugin from devices that don't meet the feature requirements mentioned above.
This behavior is not necessarily intended if app functionality provided by this plugin is preferred but not critical/required.

By specifying the aforementioned features as non-required, you enable Google Play to present your application to all users.

From [docs for Android developers](https://developer.android.com/guide/topics/manifest/uses-feature-element):
_When you declare `android:required="false"` for a feature, it means that the application prefers to use the feature if present on the device, but that it is designed to function without the specified feature, if necessary._