### PR TITLE
[fix #643] toBack feature not working

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -342,7 +342,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
           }else{
             // Default
             webViewParent = curParent;
-            ((ViewGroup)view).bringToFront();
+            ((ViewGroup)curParent).bringToFront();
           }
 
         }else{


### PR DESCRIPTION
The **toBack** feature is not working for me, using an Android 9 device. (same issue => #643)
The camera panel is displaying on top of my HTML layer (which is the cordova webView); even if the option toBack is set to 'true'. 
Note : I'm not using Capacitor.

Here's a snippet of the "toBack" feature :
```
//display camera below the webview
if(toBack){
  View view = webView.getView();
  ViewParent rootParent = containerView.getParent();
  ViewParent curParent = view.getParent();

  view.setBackgroundColor(0x00000000);

  // If parents do not match look for.
  if(curParent.getParent() != rootParent) {
    while(curParent != null && curParent.getParent() != rootParent) {
      curParent = curParent.getParent();
    }

    if(curParent != null) {
      ((ViewGroup)curParent).setBackgroundColor(0x00000000);
      ((ViewGroup)curParent).bringToFront();
    } else {
      // Do default...
      curParent = view.getParent();
      webViewParent = curParent;
      ((ViewGroup)view).bringToFront();
    }
  }else{
    // Default
    webViewParent = curParent;
    ((ViewGroup)view).bringToFront();
  }
}
```

After debugging a bit, I figured out that it was related to views hierarchy. Find below a little views tree preview of a cordova project using this plugin :
```
// Java variables
<rootParent> = containerView.getParent(); // camera-plugin parent view
<curParent> = view.getParent(); // parent of cordova webView
<view> = webView.getView(); // Cordova webView
<containerView> // camera-preview containerView

<rootParent> [android.widget.FrameLayout{5d161ea V.E...... ......ID 0,66-1080,2028 #1020002 android:id/content} (id = 16908290)]
│
├── <curParent> [android.widget.FrameLayout{b0f15d5 V.E...... ........ 0,0-1080,1962} (id = -1)]
│   └── <view> [org.apache.cordova.engine.SystemWebView{f62ca8c VFEDH.C.. .F...... 0,0-1080,1962 #64}]
│
├── <containerView> [android.widget.FrameLayout{af82cdb V.E...... ......I. 0,0-0,0 #14} (id = 20)]
│   └── ...
```
If you read the code line by line to understand which blocks are executed :
```
// If parents do not match look for.
if(curParent.getParent() != rootParent) {
```
As you can see using on the tree above, rootParent == curParent.getParent(), so we are going directly to the else condition :
```  
}else{
    // Default
    webViewParent = curParent;
    ((ViewGroup)view).bringToFront(); <========
  }
```
And this is where you call `bringToFront()` on the view to move it at the top. This is where I noticed something : 
we're doing a `bringToFront()` on the `view` object (the Cordova webView) which is not on the same level as the camera-preview view (`containerView`). `view` is actually a child of `curParent`. That's why it's doing nothing and camera-preview layer stays at the top.

By replacing the tagged line above with this :
```
((ViewGroup)curParent).bringToFront();
```
you got :
```
<rootParent> [android.widget.FrameLayout{5d161ea V.E...... ......ID 0,66-1080,2028 #1020002 android:id/content} (id = 16908290)]
│    // **bringToFront() here**
├── <curParent> [android.widget.FrameLayout{b0f15d5 V.E...... ........ 0,0-1080,1962} (id = -1)]
│   │   // **instead of here**
│   └── <view> [org.apache.cordova.engine.SystemWebView{f62ca8c VFEDH.C.. .F...... 0,0-1080,1962 #64}]
│   // **same level**
├── <containerView> [android.widget.FrameLayout{af82cdb V.E...... ......I. 0,0-0,0 #14} (id = 20)]
│   └── ...
```
And it is now working correctly.




