### PR TITLE
Fix memory leak when taking multiple snapshots

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -388,7 +388,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     data.put(originalPicture);
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, data);
-    pluginResult.setKeepCallback(true);
+    pluginResult.setKeepCallback(false);
     takeSnapshotCallbackContext.sendPluginResult(pluginResult);
     takeSnapshotCallbackContext = null;
   }

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -471,7 +471,7 @@
             NSMutableArray *params = [[NSMutableArray alloc] init];
             [params addObject:base64Image];
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
-            [pluginResult setKeepCallbackAsBool:true];
+            [pluginResult setKeepCallbackAsBool:false];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         });
     } else {


### PR DESCRIPTION
When developing an application that takes about 1 snapshot per second using this library, I noticed that the memory usage was increasing rapidly as shown on the following image:

![image](https://user-images.githubusercontent.com/19784748/128309362-96d77039-ff54-48c7-8d77-1aaa9251d7ac.png)

This was causing the application to crash or be restarted automatically.

After investigating the issue, I found that the base64 strings containing the snapshots were not being garbage collected, as shown on the following image:

![image](https://user-images.githubusercontent.com/19784748/128309786-d5102038-856b-4113-b7a3-1d32860f4ebc.png)

Also, the number of callbacks registered on cordova was increasing with every new snapshot taken, as shown on this image:

![image](https://user-images.githubusercontent.com/19784748/128309973-bd735dfc-ef2e-4d9b-9a3f-45b21188b7df.png)

Finally I switched the keepCallback property to false on the snapshot pluginResult and that allowed the base64 strings to be garbage collected, keeping the memory usage below 7MB and solving the memory leak.

This was very similar to what happened on [this issue](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/604).