### PR TITLE
[Fix] Custom UI overlain

### DIFF
--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -342,7 +342,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
           }else{
             // Default
             webViewParent = curParent;
-            ((ViewGroup)curParent).bringToFront();
+            rootParent.bringChildToFront(((View) webViewParent));
           }
 
         }else{
@@ -388,7 +388,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     data.put(originalPicture);
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, data);
-    pluginResult.setKeepCallback(false);
+    pluginResult.setKeepCallback(true);
     takeSnapshotCallbackContext.sendPluginResult(pluginResult);
     takeSnapshotCallbackContext = null;
   }

--- a/src/ios/CameraPreview.h
+++ b/src/ios/CameraPreview.h
@@ -49,3 +49,23 @@
 @property (nonatomic) BOOL storeToFile;
 
 @end
+
+// get all subViews recursively
+// UIView+viewRecursion.h
+@interface UIView (viewRecursion)
+- (NSMutableArray*) allSubViews;
+@end
+
+// UIView+viewRecursion.m
+@implementation UIView (viewRecursion)
+- (NSMutableArray*)allSubViews
+{
+   NSMutableArray *arr = [NSMutableArray array];
+   [arr addObject:self];
+   for (UIView *subview in self.subviews)
+   {
+     [arr addObjectsFromArray:(NSArray*)[subview allSubViews]];
+   }
+   return arr;
+}
+@end

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -50,20 +50,34 @@
     self.cameraRenderController.view.frame = CGRectMake(x, y, width, height);
     self.cameraRenderController.delegate = self;
 
-    [self.viewController addChildViewController:self.cameraRenderController];
+    //useless - GV
+    //[self.viewController addChildViewController:self.cameraRenderController];
 
     if (toBack) {
       // display the camera below the webview
-
-      // make transparent
+      // make webView transparent
       self.webView.opaque = NO;
       self.webView.backgroundColor = [UIColor clearColor];
+        
+      for (UIView *i in self.viewController.view.subviews) {
+          NSString *nameOfClass = NSStringFromClass([i class]);
+          NSLog(@"Class of subview is %@",nameOfClass);
+          if ([nameOfClass isEqualToString:@"WKScrollView"]) {
+              self.webView = i;
+          }
+      }
 
-      [self.webView.superview addSubview:self.cameraRenderController.view];
-      [self.webView.superview bringSubviewToFront:self.webView];
+      [self.viewController.view addSubview:self.cameraRenderController.view];
+      [self.viewController.view bringSubviewToFront:self.webView];
+      // make every subview transparent - GV
+      for(UIView *v in [self.webView allSubViews])
+      {
+          v.opaque = NO;
+          v.backgroundColor = [[UIColor clearColor] colorWithAlphaComponent:0.0f];
+      }
     } else {
-      self.cameraRenderController.view.alpha = alpha;
-      [self.webView.superview insertSubview:self.cameraRenderController.view aboveSubview:self.webView];
+        self.cameraRenderController.view.alpha = alpha;
+        [self.viewController.view insertSubview:self.cameraRenderController.view aboveSubview:self.webView];
     }
 
     // Setup session
@@ -471,7 +485,7 @@
             NSMutableArray *params = [[NSMutableArray alloc] init];
             [params addObject:base64Image];
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
-            [pluginResult setKeepCallbackAsBool:false];
+            [pluginResult setKeepCallbackAsBool:true];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         });
     } else {


### PR DESCRIPTION
This pull request aims to fix custom UI elements being overlain by the plugin view. Without this change, the plugin view is always brought to the front and essentially hides any custom UI elements.

Here are the options we used:
```typescript
const options: CameraPreviewOptions = {
    camera: this.cameraPreview.CAMERA_DIRECTION.BACK,
    width: window.innerWidth,
    height: window.innerHeight,
    tapFocus: true,
    tapPhoto: false,
    toBack: true,
    alpha: 1,
};
```