### PR TITLE
Fix #660 - Camera preview not going to back in Ionic Capacitor

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -59,7 +59,10 @@
       self.webView.opaque = NO;
       self.webView.backgroundColor = [UIColor clearColor];
 
-      [self.webView.superview addSubview:self.cameraRenderController.view];
+      self.webView.scrollView.opaque = NO;
+      self.webView.scrollView.backgroundColor = [UIColor clearColor];
+
+      [self.viewController.view insertSubview:self.cameraRenderController.view atIndex:0];
       [self.webView.superview bringSubviewToFront:self.webView];
     } else {
       self.cameraRenderController.view.alpha = alpha;


### PR DESCRIPTION
Applied the solution suggested in #660.

Thanks to @acyvas and @TreehouseNorris.