### PR TITLE
Remove unused permissions READ_MEDIA_IMAGES and READ_MEDIA_VIDEOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,8 +38,6 @@
       <uses-permission android:name="android.permission.CAMERA" />
       <uses-permission android:name="android.permission.RECORD_AUDIO" />
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-      <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-      <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
This change should make the plugin compliance with new Android rules when requesting the READ_MEDIA_IMAGES or READ_MEDIA_VIDEOS persmissions.

Since those permissions are not used by plugin, the recommendation is to remove from manifest.

Resolves the Issue https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/issues/706