### PR TITLE
Fix dark first image on Android (Camera1 API)

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -297,9 +297,7 @@ public class CameraActivity extends Fragment {
       if(mPreview.mPreviewSize == null){
         mPreview.setCamera(mCamera, cameraCurrentlyLocked);
 
-        // Pre-configure picture parameters so we don't need to call
-        // setParameters() right before takePicture() — that resets the
-        // auto-exposure pipeline and causes the first image to be dark.
+        // Pre-configure picture parameters to reset AE pipeline
         configurePictureParameters();
 
         // Don't immediately call the callback - post it as a delayed action
@@ -686,17 +684,11 @@ public class CameraActivity extends Fragment {
     });
   }
 
-  /**
-   * Pre-configure picture parameters (size, quality, rotation) on the camera
-   * so that takePicture() does NOT need to call setParameters() immediately
-   * before capture. Calling setParameters() resets the auto-exposure/AWB
-   * pipeline, which causes the very first captured image to be dark.
-   */
+  // Pre-configure picture parameters (size, quality, rotation)
   private void configurePictureParameters() {
     if (mCamera == null || mPreview == null) return;
     try {
       Camera.Parameters params = mCamera.getParameters();
-      // Use 0,0 to let getOptimalPictureSize pick the best resolution
       Camera.Size size = getOptimalPictureSize(0, 0, params.getPreviewSize(), params.getSupportedPictureSizes());
       params.setPictureSize(size.width, size.height);
       params.setJpegQuality(85);
@@ -717,11 +709,7 @@ public class CameraActivity extends Fragment {
       }
 
       canTakePicture = false;
-
-      // Run on the UI thread — Camera1 API requires camera operations
-      // on the same thread that opened the camera.
-      // Only update parameters if the requested size/quality differs
-      // from what was pre-configured, to avoid resetting AE.
+      
       Activity activity = getActivity();
       if (activity == null) {
         canTakePicture = true;

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -297,6 +297,11 @@ public class CameraActivity extends Fragment {
       if(mPreview.mPreviewSize == null){
         mPreview.setCamera(mCamera, cameraCurrentlyLocked);
 
+        // Pre-configure picture parameters so we don't need to call
+        // setParameters() right before takePicture() — that resets the
+        // auto-exposure pipeline and causes the first image to be dark.
+        configurePictureParameters();
+
         // Don't immediately call the callback - post it as a delayed action
         // to ensure the listener is properly set up when it's called
         if (eventListener != null) {
@@ -312,6 +317,7 @@ public class CameraActivity extends Fragment {
       } else {
         mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
         mCamera.startPreview();
+        configurePictureParameters();
       }
 
       Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
@@ -680,6 +686,28 @@ public class CameraActivity extends Fragment {
     });
   }
 
+  /**
+   * Pre-configure picture parameters (size, quality, rotation) on the camera
+   * so that takePicture() does NOT need to call setParameters() immediately
+   * before capture. Calling setParameters() resets the auto-exposure/AWB
+   * pipeline, which causes the very first captured image to be dark.
+   */
+  private void configurePictureParameters() {
+    if (mCamera == null || mPreview == null) return;
+    try {
+      Camera.Parameters params = mCamera.getParameters();
+      // Use 0,0 to let getOptimalPictureSize pick the best resolution
+      Camera.Size size = getOptimalPictureSize(0, 0, params.getPreviewSize(), params.getSupportedPictureSizes());
+      params.setPictureSize(size.width, size.height);
+      params.setJpegQuality(85);
+      params.setRotation(mPreview.getDisplayOrientation());
+      mCamera.setParameters(params);
+      Log.d(TAG, "Picture parameters pre-configured: " + size.width + "x" + size.height);
+    } catch (Exception e) {
+      Log.e(TAG, "Error pre-configuring picture parameters", e);
+    }
+  }
+
   public void takePicture(final int width, final int height, final int quality){
     Log.d(TAG, "CameraPreview takePicture width: " + width + ", height: " + height + ", quality: " + quality);
 
@@ -690,23 +718,38 @@ public class CameraActivity extends Fragment {
 
       canTakePicture = false;
 
-      new Thread() {
+      // Run on the UI thread — Camera1 API requires camera operations
+      // on the same thread that opened the camera.
+      // Only update parameters if the requested size/quality differs
+      // from what was pre-configured, to avoid resetting AE.
+      Activity activity = getActivity();
+      if (activity == null) {
+        canTakePicture = true;
+        return;
+      }
+      activity.runOnUiThread(new Runnable() {
+        @Override
         public void run() {
           try {
             if (mCamera == null) {
               Log.d(TAG, "Camera is null, cannot take picture");
-              canTakePicture = true; // Reset flag if camera is null
+              canTakePicture = true;
               return;
             }
-            
-            Camera.Parameters params = mCamera.getParameters();
 
-            Camera.Size size = getOptimalPictureSize(width, height, params.getPreviewSize(), params.getSupportedPictureSizes());
-            params.setPictureSize(size.width, size.height);
+            Camera.Parameters params = mCamera.getParameters();
             currentQuality = quality;
 
+            // Only update picture size if a specific size was requested
+            if (width > 0 && height > 0) {
+              Camera.Size currentSize = params.getPictureSize();
+              Camera.Size optimalSize = getOptimalPictureSize(width, height, params.getPreviewSize(), params.getSupportedPictureSizes());
+              if (currentSize.width != optimalSize.width || currentSize.height != optimalSize.height) {
+                params.setPictureSize(optimalSize.width, optimalSize.height);
+              }
+            }
+
             if(cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT && !storeToFile) {
-              // The image will be recompressed in the callback
               params.setJpegQuality(99);
             } else {
               params.setJpegQuality(quality);
@@ -714,15 +757,40 @@ public class CameraActivity extends Fragment {
 
             params.setRotation(mPreview.getDisplayOrientation());
 
-            mCamera.setParameters(params);
-            mCamera.takePicture(shutterCallback, null, jpegPictureCallback);
+            // Check if parameters actually changed before calling setParameters
+            Camera.Parameters currentParams = mCamera.getParameters();
+            boolean paramsChanged = 
+              currentParams.getJpegQuality() != params.getJpegQuality() ||
+              currentParams.getPictureSize().width != params.getPictureSize().width ||
+              currentParams.getPictureSize().height != params.getPictureSize().height;
+
+            if (paramsChanged) {
+              mCamera.setParameters(params);
+              // If we had to change params, give AE a moment to restabilize
+              new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                  try {
+                    if (mCamera != null) {
+                      mCamera.takePicture(shutterCallback, null, jpegPictureCallback);
+                    } else {
+                      canTakePicture = true;
+                    }
+                  } catch (Exception e) {
+                    canTakePicture = true;
+                    Log.e(TAG, "Error taking picture after param change", e);
+                  }
+                }
+              }, 500);
+            } else {
+              mCamera.takePicture(shutterCallback, null, jpegPictureCallback);
+            }
           } catch (Exception e) {
-            // Reset flag so future attempts can be made
             canTakePicture = true;
             Log.e(TAG, "Error taking picture", e);
           }
         }
-      }.start();
+      });
     } else {
       canTakePicture = true;
     }


### PR DESCRIPTION
### Problem
On certain Android devices (observed on POCO F5), the very first image captured by the plugin is extremely dark / underexposed. Subsequent captures are fine.

### Root cause
The Camera1 setParameters() call resets the auto-exposure (AE) and auto-white-balance (AWB) convergence pipeline. The previous implementation called setParameters() inside takePicture() right before Camera.takePicture(), meaning the AE state was always disrupted on the first capture — before the pipeline had a chance to reconverge.

### Fix
Pre-configure picture parameters at startup — a new configurePictureParameters() method sets picture size, JPEG quality, and rotation immediately after the camera opens in onResume(). This ensures parameters are already applied by the time the user takes a photo.
Avoid redundant setParameters() calls — takePicture() now compares the requested parameters against the current camera state and only calls setParameters() when something actually changed.
AE restabilization delay — if a parameter change is unavoidable, a 500 ms delay is introduced before capture to allow the AE pipeline to reconverge.
Thread safety — takePicture() is moved from a background Thread to Activity.runOnUiThread(), which is the correct threading model for the Camera1 API.

### Affected device(s)
POCO F5 (confirmed)
Likely affects other devices with aggressive AE reset behavior

### Testing
First capture is no longer dark on POCO F5
Subsequent captures continue to work correctly
Camera switching still functions properly
